### PR TITLE
fix(docker): bundle Studio into the jar — single origin, fixes #1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,8 @@
 **/build
 **/*.tsbuildinfo
 frontend/apps/www
+frontend/.maven-frontend
+frontend/apps/studio/out
 
 logs
 parser_logs

--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -4,32 +4,15 @@ FROM maven:3.9-eclipse-temurin-17 AS backend-builder
 
 WORKDIR /workspace
 COPY pom.xml .
-RUN --mount=type=cache,target=/root/.m2 mvn -B dependency:go-offline
 COPY src ./src
-RUN --mount=type=cache,target=/root/.m2 mvn -B clean package -Dmaven.test.skip=true
-
-FROM node:20-bookworm-slim AS studio-builder
-
-WORKDIR /workspace/frontend
-RUN corepack enable
-
-COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
-COPY frontend/tsconfig.base.json ./
-COPY frontend/packages ./packages
-COPY frontend/apps/studio ./apps/studio
-
-# Leave empty so the Studio bundle uses RELATIVE API paths; the Next standalone server
-# proxies them to the backend inside the container (see apps/studio/next.config.mjs). The
-# image then works at any server IP/domain with no rebuild. Only set this to an ABSOLUTE URL
-# if you serve Studio and the API on separate origins without the built-in proxy.
-ARG NEXT_PUBLIC_NUBASE_API_URL=
-ENV NEXT_PUBLIC_NUBASE_API_URL=${NEXT_PUBLIC_NUBASE_API_URL}
-
-RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm config set store-dir /pnpm/store && \
-    mkdir -p apps/studio/public && \
-    pnpm install --no-frozen-lockfile && \
-    pnpm --filter @nubase/studio build
+# Bundle the Studio UI into the jar (served same-origin at /studio) via the `with-frontend`
+# profile: frontend-maven-plugin self-installs Node+pnpm and static-exports Studio into the
+# jar's resources. A single `java -jar` then serves both the API (/auth/v1, /rest/v1, …) and
+# the UI (/studio) on one port — so the deployment works at any server IP/domain with no
+# cross-origin "localhost" problem and no separate frontend process.
+COPY frontend ./frontend
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -Pwith-frontend clean package -Dmaven.test.skip=true
 
 FROM pgvector/pgvector:pg15
 
@@ -43,17 +26,12 @@ RUN apt-get -o Acquire::Retries=5 update && \
       openjdk-17-jre-headless \
       openssl \
       redis-server && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/nubase
 
 COPY --from=backend-builder /workspace/target/*.jar /opt/nubase/backend/app.jar
-COPY --from=studio-builder /workspace/frontend/apps/studio/.next/standalone /opt/nubase/studio
-COPY --from=studio-builder /workspace/frontend/apps/studio/.next/static /opt/nubase/studio/apps/studio/.next/static
-COPY --from=studio-builder /workspace/frontend/apps/studio/public /opt/nubase/studio/apps/studio/public
 COPY docker/all-in-one/entrypoint.sh /usr/local/bin/nubase-entrypoint
 
 RUN chmod +x /usr/local/bin/nubase-entrypoint && \
@@ -69,14 +47,13 @@ ENV PGDATA=/data/postgres \
     REDIS_HOST=127.0.0.1 \
     REDIS_PORT=6379 \
     NUBASE_CACHE_TYPE=caffeine \
-    SERVER_PORT=9999 \
-    PORT=3000 \
-    HOSTNAME=0.0.0.0
+    SERVER_PORT=9999
 
 VOLUME ["/data"]
-EXPOSE 3000 9999 5432
+# Single app port: 9999 serves both the API and the Studio UI (/studio). 5432 = Postgres.
+EXPOSE 9999 5432
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=5 \
-  CMD nc -z 127.0.0.1 9999 && curl -fsS http://127.0.0.1:3000 >/dev/null || exit 1
+  CMD nc -z 127.0.0.1 9999 && curl -fsS -o /dev/null http://127.0.0.1:9999/studio/ || exit 1
 
 ENTRYPOINT ["dumb-init", "--", "nubase-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ The all-in-one Docker image bundles **PostgreSQL + Redis + the backend + Studio*
 
 ```bash
 docker run -d --name nubase \
-  -p 3000:3000 -p 9999:9999 -p 5432:5432 \
+  -p 9999:9999 -p 5432:5432 \
   -v nubase_data:/data \
   <your-namespace>/nubase:latest
 ```
 
-- **Studio** → http://localhost:3000 — create an account, create a project, click **Provision** to initialize its database.
-- **API** → http://localhost:9999
+- **Studio** → http://localhost:9999/studio — create an account, create a project, click **Provision** to initialize its database.
+- **API** → http://localhost:9999 (the Studio UI is bundled into the backend and served on the same port)
 
 > First-boot secrets are generated into the `/data` volume; keep the volume to retain your projects. For a real deployment with stable secrets, see [Self-host with Docker](#-self-host-with-docker).
 
@@ -76,14 +76,14 @@ The single all-in-one image is everything you need to run Nubase on your own box
 **Try it (auto-generated secrets, kept in the volume):**
 
 ```bash
-docker run -d --name nubase -p 3000:3000 -p 9999:9999 -p 5432:5432 \
+docker run -d --name nubase -p 9999:9999 -p 5432:5432 \
   -v nubase_data:/data <your-namespace>/nubase:latest
 ```
 
 **Production (pin stable secrets so encrypted project credentials survive restarts):**
 
 ```bash
-docker run -d --name nubase -p 3000:3000 -p 9999:9999 -p 5432:5432 \
+docker run -d --name nubase -p 9999:9999 -p 5432:5432 \
   -v nubase_data:/data \
   -e PGRST_ENCRYPTION_MASTER_KEY="$(openssl rand -base64 32)" \
   -e METADATA_SERVICE_ROLE_KEY="$(openssl rand -base64 48)" \

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,13 +49,13 @@ npx -y nubase_cli@latest install-skills
 
 ```bash
 docker run -d --name nubase \
-  -p 3000:3000 -p 9999:9999 -p 5432:5432 \
+  -p 9999:9999 -p 5432:5432 \
   -v nubase_data:/data \
   <your-namespace>/nubase:latest
 ```
 
-- **Studio** → http://localhost:3000 —— 创建账号、创建项目，点击 **Provision** 初始化项目数据库。
-- **API** → http://localhost:9999
+- **Studio** → http://localhost:9999/studio —— 创建账号、创建项目，点击 **Provision** 初始化项目数据库。
+- **API** → http://localhost:9999（Studio 界面已打包进后端，同端口提供）
 
 > 首次启动的密钥会生成到 `/data` 卷中；保留该卷即可保留你的项目。如需带稳定密钥的正式部署，见 [使用 Docker 自托管](#-使用-docker-自托管)。
 
@@ -76,14 +76,14 @@ docker run -d --name nubase \
 **试用（自动生成密钥，保存在卷中）：**
 
 ```bash
-docker run -d --name nubase -p 3000:3000 -p 9999:9999 -p 5432:5432 \
+docker run -d --name nubase -p 9999:9999 -p 5432:5432 \
   -v nubase_data:/data <your-namespace>/nubase:latest
 ```
 
 **生产（固定稳定密钥，让加密的项目凭据在重启后依然可用）：**
 
 ```bash
-docker run -d --name nubase -p 3000:3000 -p 9999:9999 -p 5432:5432 \
+docker run -d --name nubase -p 9999:9999 -p 5432:5432 \
   -v nubase_data:/data \
   -e PGRST_ENCRYPTION_MASTER_KEY="$(openssl rand -base64 32)" \
   -e METADATA_SERVICE_ROLE_KEY="$(openssl rand -base64 48)" \

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -106,23 +106,14 @@ start_backend() {
   export REDIS_HOST="${REDIS_HOST:-127.0.0.1}"
   export SERVER_PORT="${SERVER_PORT:-9999}"
 
-  log "Starting backend on port ${SERVER_PORT}"
+  # The jar serves both the API and the bundled Studio UI (/studio) on this one port.
+  log "Starting backend (API + Studio UI) on port ${SERVER_PORT}"
   java ${JAVA_OPTS:-} -jar /opt/nubase/backend/app.jar &
   BACKEND_PID=$!
 }
 
-start_studio() {
-  export PORT="${PORT:-3000}"
-  export HOSTNAME="${HOSTNAME:-0.0.0.0}"
-
-  log "Starting Studio on port ${PORT}"
-  node /opt/nubase/studio/apps/studio/server.js &
-  STUDIO_PID=$!
-}
-
 shutdown() {
   log "Stopping services"
-  [ -n "${STUDIO_PID:-}" ] && kill "$STUDIO_PID" 2>/dev/null || true
   [ -n "${BACKEND_PID:-}" ] && kill "$BACKEND_PID" 2>/dev/null || true
   redis-cli -h 127.0.0.1 -p "${REDIS_PORT:-6379}" shutdown 2>/dev/null || true
   su postgres -c "/usr/lib/postgresql/15/bin/pg_ctl -D '$PGDATA' -m fast -w stop" 2>/dev/null || true
@@ -134,6 +125,5 @@ ensure_secrets
 init_postgres
 start_redis
 start_backend
-start_studio
 
-wait -n "$BACKEND_PID" "$STUDIO_PID"
+wait "$BACKEND_PID"

--- a/docs/docker-all-in-one.md
+++ b/docs/docker-all-in-one.md
@@ -2,8 +2,7 @@
 
 This repository can publish one Docker image that runs:
 
-- Nubase backend on port `9999`
-- Nubase Studio on port `3000`
+- Nubase backend **and the Studio UI** on port `9999` (the Studio is bundled into the jar and served at `/studio`, same-origin with the API)
 - PostgreSQL 15 with `pgvector` on port `5432`
 - Redis internally for OAuth state support
 
@@ -34,7 +33,6 @@ Replace `<dockerhub-user>` with the Docker Hub namespace used by the release wor
 ```bash
 docker run -d \
   --name nubase \
-  -p 3000:3000 \
   -p 9999:9999 \
   -p 5432:5432 \
   -v nubase_data:/data \
@@ -43,19 +41,17 @@ docker run -d \
 
 Open:
 
-- Studio: http://localhost:3000
-- Backend: http://localhost:9999
+- Studio UI: http://localhost:9999/studio
+- API: http://localhost:9999
 - Postgres: `localhost:5432`, database `postgrest_metadata`, user `postgres`, password `postgres`
 
 ### Accessing from a remote server
 
-When the container runs on a remote host, just open Studio at the server's address —
-`http://<server-ip>:3000` (or your domain). Studio calls the backend through **relative
-paths** that the bundled Next server proxies to the API inside the container, so login and
-all API calls follow whatever host you used — no `localhost` hardcoding and no rebuild when
-the IP or domain changes. Expose port `9999` as well if external agents/MCP clients connect
-directly to the API. (Advanced: to serve Studio and the API on separate origins without the
-built-in proxy, rebuild with `--build-arg NEXT_PUBLIC_NUBASE_API_URL=https://api.example.com`.)
+The Studio UI and the API are served by a **single process on one port (`9999`), same-origin**.
+When the container runs on a remote host, just open `http://<server-ip>:9999/studio` (or your
+domain). The UI calls the API with relative paths, so login and every request follow whatever
+host you opened — there is no hardcoded `localhost` and no rebuild when the IP or domain
+changes. Only port `9999` needs to be reachable.
 
 The container creates persistent secrets under the `/data` volume when they are not provided through environment variables. Keep the same volume across restarts so encrypted project credentials remain readable.
 
@@ -64,7 +60,6 @@ For production-like installs, set stable secrets explicitly:
 ```bash
 docker run -d \
   --name nubase \
-  -p 3000:3000 \
   -p 9999:9999 \
   -p 5432:5432 \
   -v nubase_data:/data \


### PR DESCRIPTION
## Fixes #1 — 服务器部署登录接口调用 localhost

### 根因
all-in-one 镜像把 Studio 当作独立的 Next standalone 进程跑在 `:3000`,后端 API 在 `:9999`,并在**构建期**把 `NEXT_PUBLIC_NUBASE_API_URL=http://localhost:9999` 内联进了浏览器 JS 包。`NEXT_PUBLIC_*` 是 build-time 写死的,所以远程访问时登录/OAuth/所有 API 都打到**访客自己机器**的 `localhost:9999` → 连不上(服务器 IP 与 localhost 不兼容)。

### 修复
改用 `with-frontend` Maven profile,把 Studio **静态导出并打进 jar**,由后端在 `:9999/studio` **同源**托管:

- 单进程、单应用端口(`9999`),前端用相对路径调 API → 登录与每个请求都跟随访问地址,任意 IP/域名零配置生效、换机器无需重构建。
- `Dockerfile.all-in-one`:用 `-Pwith-frontend` 构建;删掉 Node `studio-builder` 阶段和运行时 Node 安装;只暴露 `9999` + `5432`。
- `entrypoint.sh`:删掉 Studio node 进程,只 `wait` 后端。
- docs / README(中英):单端口,Studio 在 `/studio`。
- `.dockerignore`:排除前端构建产物。

### 验证
本地 `mvn -B -Pwith-frontend clean package -Dmaven.test.skip=true` → **BUILD SUCCESS**,产出单 jar(102M)内含 **202 个 Studio 静态文件**(`BOOT-INF/classes/static/studio/index.html`、`_next`、`login`、`projects` …)。

发布新镜像后,访问 `http://<服务器IP>:9999/studio` 即可正常登录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
