### PR TITLE
[codex] Add Studio i18n language switch

### DIFF
--- a/frontend/apps/studio/src/app/(app)/account/page.tsx
+++ b/frontend/apps/studio/src/app/(app)/account/page.tsx
@@ -15,10 +15,12 @@ import {
 } from '@nubase/ui';
 import { apiFetch, type ApiError } from '@/lib/api';
 import { useSession } from '@/lib/session';
+import { useI18n } from '@/lib/i18n';
 
 export default function AccountPage() {
   const router = useRouter();
   const { user, platformKey, hasHydrated } = useSession();
+  const { tr } = useI18n();
 
   useEffect(() => {
     if (!hasHydrated) return;
@@ -31,20 +33,20 @@ export default function AccountPage() {
   return (
     <div className="w-full max-w-2xl space-y-6 p-8">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Account</h1>
-        <p className="text-sm text-muted-foreground">Your platform user profile.</p>
+        <h1 className="text-2xl font-semibold tracking-tight">{tr('account.title')}</h1>
+        <p className="text-sm text-muted-foreground">{tr('account.subtitle')}</p>
       </header>
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Profile</CardTitle>
-          <CardDescription>Identity used when calling the platform API.</CardDescription>
+          <CardTitle className="text-base">{tr('account.profile')}</CardTitle>
+          <CardDescription>{tr('account.profileDescription')}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-3 text-sm">
-          <Row label="Email" value={user.email} />
-          <Row label="Full name" value={user.fullName || '—'} />
+          <Row label={tr('auth.email')} value={user.email} />
+          <Row label={tr('account.fullName')} value={user.fullName || '—'} />
           <div className="grid grid-cols-[140px_1fr] gap-4">
-            <span className="text-xs text-muted-foreground">Role</span>
+            <span className="text-xs text-muted-foreground">{tr('account.role')}</span>
             <div>
               {user.role === 'super_admin' ? (
                 <Badge variant="success">super admin</Badge>
@@ -53,12 +55,12 @@ export default function AccountPage() {
               )}
               <p className="mt-1 text-xs text-muted-foreground">
                 {user.role === 'super_admin'
-                  ? 'You can see every project in this workspace.'
-                  : 'You can only see projects you own or were invited to.'}
+                  ? tr('account.roleSuper')
+                  : tr('account.roleUser')}
               </p>
             </div>
           </div>
-          <Row label="User ID" value={user.id} mono />
+          <Row label={tr('account.userId')} value={user.id} mono />
         </CardContent>
       </Card>
 
@@ -68,6 +70,7 @@ export default function AccountPage() {
 }
 
 function ChangePasswordCard({ bearer }: { bearer: string | null }) {
+  const { tr } = useI18n();
   // 'form' collects passwords; 'code' is shown after a code has been emailed.
   const [step, setStep] = useState<'form' | 'code'>('form');
   const [currentPassword, setCurrentPassword] = useState('');
@@ -89,9 +92,9 @@ function ChangePasswordCard({ bearer }: { bearer: string | null }) {
         body: { currentPassword },
       });
       setStep('code');
-      setNotice('We emailed you a 6-digit confirmation code.');
+      setNotice(tr('account.passwordOtpSent'));
     } catch (err) {
-      setError(parseError(err as ApiError) ?? 'Could not start the password change.');
+      setError(parseError(err as ApiError) ?? tr('account.passwordOtpFailed'));
     } finally {
       setLoading(false);
     }
@@ -111,9 +114,9 @@ function ChangePasswordCard({ bearer }: { bearer: string | null }) {
       setCurrentPassword('');
       setNewPassword('');
       setCode('');
-      setNotice('Password updated.');
+      setNotice(tr('account.passwordUpdated'));
     } catch (err) {
-      setError(parseError(err as ApiError) ?? 'Could not change the password.');
+      setError(parseError(err as ApiError) ?? tr('account.passwordChangeFailed'));
     } finally {
       setLoading(false);
     }
@@ -122,16 +125,14 @@ function ChangePasswordCard({ bearer }: { bearer: string | null }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Security</CardTitle>
-        <CardDescription>
-          Change your password. We email a confirmation code to verify it&apos;s you.
-        </CardDescription>
+        <CardTitle className="text-base">{tr('account.security')}</CardTitle>
+        <CardDescription>{tr('account.securityDescription')}</CardDescription>
       </CardHeader>
       <CardContent>
         {step === 'form' ? (
           <form onSubmit={requestCode} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="currentPassword">Current password</Label>
+              <Label htmlFor="currentPassword">{tr('account.currentPassword')}</Label>
               <Input
                 id="currentPassword"
                 type="password"
@@ -142,7 +143,7 @@ function ChangePasswordCard({ bearer }: { bearer: string | null }) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="newPassword">New password</Label>
+              <Label htmlFor="newPassword">{tr('account.newPassword')}</Label>
               <Input
                 id="newPassword"
                 type="password"
@@ -152,18 +153,18 @@ function ChangePasswordCard({ bearer }: { bearer: string | null }) {
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
               />
-              <p className="text-xs text-muted-foreground">At least 8 characters.</p>
+              <p className="text-xs text-muted-foreground">{tr('auth.signup.passwordHelp')}</p>
             </div>
             {notice ? <p className="text-xs text-muted-foreground">{notice}</p> : null}
             {error ? <p className="text-xs text-destructive">{error}</p> : null}
             <Button type="submit" disabled={loading}>
-              {loading ? 'Sending code…' : 'Continue'}
+              {loading ? tr('account.sendingCode') : tr('account.continue')}
             </Button>
           </form>
         ) : (
           <form onSubmit={confirmChange} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="pwCode">Confirmation code</Label>
+              <Label htmlFor="pwCode">{tr('account.confirmationCode')}</Label>
               <Input
                 id="pwCode"
                 inputMode="numeric"
@@ -179,7 +180,7 @@ function ChangePasswordCard({ bearer }: { bearer: string | null }) {
             {error ? <p className="text-xs text-destructive">{error}</p> : null}
             <div className="flex gap-2">
               <Button type="submit" disabled={loading || code.length < 6}>
-                {loading ? 'Updating…' : 'Change password'}
+                {loading ? tr('account.updating') : tr('account.changePassword')}
               </Button>
               <Button
                 type="button"
@@ -191,7 +192,7 @@ function ChangePasswordCard({ bearer }: { bearer: string | null }) {
                   setNotice(null);
                 }}
               >
-                Cancel
+                {tr('account.cancel')}
               </Button>
             </div>
           </form>

--- a/frontend/apps/studio/src/app/(app)/new/page.tsx
+++ b/frontend/apps/studio/src/app/(app)/new/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@nubase/ui';
 import { apiFetch, type ApiError } from '@/lib/api';
 import { useSession } from '@/lib/session';
+import { useI18n } from '@/lib/i18n';
 
 const REGIONS = [
   { value: 'us-east-1', label: 'US East (N. Virginia)' },
@@ -45,6 +46,7 @@ export default function NewProjectPage() {
   const router = useRouter();
   const { toast } = useToast();
   const { platformKey, hasHydrated, setProject } = useSession();
+  const { tr } = useI18n();
 
   const [name, setName] = useState('');
   const [ref, setRef] = useState('');
@@ -87,12 +89,12 @@ export default function NewProjectPage() {
       // provisioning (phase 2) on mount — the user doesn't have to click anything.
       // Keeping create and provision as separate calls keeps the UI responsive and
       // lets the same auto-provision path recover historical stuck projects.
-      toast({ variant: 'success', title: 'Project created', message: 'Initializing the database…' });
+      toast({ variant: 'success', title: tr('newProject.created'), message: tr('newProject.initializing') });
       router.push(`/project/${appCode}`);
     } catch (err) {
-      const msg = parseError(err as ApiError) ?? 'Failed to create project.';
+      const msg = parseError(err as ApiError) ?? tr('newProject.failed');
       setError(msg);
-      toast({ variant: 'error', title: 'Create failed', message: msg });
+      toast({ variant: 'error', title: tr('newProject.createFailed'), message: msg });
       setLoading(false);
     }
   }
@@ -107,27 +109,24 @@ export default function NewProjectPage() {
     <div className="w-full max-w-2xl p-8">
       <Card>
         <CardHeader>
-          <CardTitle>New project</CardTitle>
-          <CardDescription>
-            Save a project configuration. The Postgres database is provisioned automatically on the
-            next screen.
-          </CardDescription>
+          <CardTitle>{tr('newProject.title')}</CardTitle>
+          <CardDescription>{tr('newProject.subtitle')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={onSubmit} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="name">Project name</Label>
+              <Label htmlFor="name">{tr('newProject.name')}</Label>
               <Input
                 id="name"
                 required
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="My CRM"
+                placeholder={tr('newProject.namePlaceholder')}
               />
-              <p className="text-xs text-muted-foreground">Shown in the dashboard.</p>
+              <p className="text-xs text-muted-foreground">{tr('newProject.nameHelp')}</p>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="ref">Reference</Label>
+              <Label htmlFor="ref">{tr('newProject.ref')}</Label>
               <Input
                 id="ref"
                 required
@@ -141,21 +140,20 @@ export default function NewProjectPage() {
                 className="font-mono"
               />
               <p className="text-xs text-muted-foreground">
-                Lower-case, digits and underscores. Used as the API path segment, database name and JWT
-                <code className="mx-1">ref</code> claim. Cannot be changed later.
+                {tr('newProject.refHelp')}
               </p>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="description">Description (optional)</Label>
+              <Label htmlFor="description">{tr('newProject.description')}</Label>
               <Input
                 id="description"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                placeholder="Internal CRM data"
+                placeholder={tr('newProject.descriptionPlaceholder')}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="region">Region</Label>
+              <Label htmlFor="region">{tr('newProject.region')}</Label>
               <select
                 id="region"
                 value={region}
@@ -169,16 +167,16 @@ export default function NewProjectPage() {
                 ))}
               </select>
               <p className="text-xs text-muted-foreground">
-                Visual only for now — self-hosted nubase runs against a single Postgres host.
+                {tr('newProject.regionHelp')}
               </p>
             </div>
             {error ? <p className="text-xs text-destructive">{error}</p> : null}
             <div className="flex justify-end gap-2 pt-2">
               <Button type="button" variant="outline" onClick={() => router.back()} disabled={loading}>
-                Cancel
+                {tr('newProject.cancel')}
               </Button>
               <Button type="submit" disabled={loading || !effectiveRef}>
-                {loading ? 'Creating…' : 'Create project'}
+                {loading ? tr('newProject.creating') : tr('newProject.create')}
               </Button>
             </div>
           </form>

--- a/frontend/apps/studio/src/app/(app)/projects/page.tsx
+++ b/frontend/apps/studio/src/app/(app)/projects/page.tsx
@@ -26,6 +26,7 @@ import {
 } from '@nubase/ui';
 import { apiFetch, type ApiError } from '@/lib/api';
 import { useSession, isSuperAdmin } from '@/lib/session';
+import { useI18n } from '@/lib/i18n';
 
 interface ProjectSummary {
   ref: string;
@@ -71,6 +72,7 @@ function meaningfulDescription(p: { description?: string | null; ref: string; na
 
 export default function ProjectsPage() {
   const router = useRouter();
+  const { tr } = useI18n();
   const { platformKey, user, setProject, signOut, hasHydrated } = useSession();
   const superAdmin = isSuperAdmin(user);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
@@ -114,7 +116,7 @@ export default function ProjectsPage() {
           router.replace('/login');
           return;
         }
-        setError(err.message ?? 'Failed to load projects.');
+        setError(err.message ?? tr('projects.loadError'));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -122,7 +124,7 @@ export default function ProjectsPage() {
     return () => {
       cancelled = true;
     };
-  }, [hasHydrated, platformKey, router, signOut]);
+  }, [hasHydrated, platformKey, router, signOut, tr]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -165,34 +167,33 @@ export default function ProjectsPage() {
           <div className="min-w-0">
             <div className="mb-2 flex items-center gap-2">
               <span className="rounded-md border border-border bg-background px-2 py-1 font-mono text-[11px] text-muted-foreground">
-                workspace
+                {tr('projects.scope')}
               </span>
               {superAdmin ? (
                 <span className="rounded-md bg-brand/10 px-2 py-1 text-[11px] font-medium text-brand">
-                  super admin
+                  {tr('projects.superAdmin')}
                 </span>
               ) : null}
             </div>
             <h1 className="text-2xl font-semibold tracking-tight">
-              {superAdmin ? 'All projects' : 'Your projects'}
+              {superAdmin ? tr('projects.titleAll') : tr('projects.titleOwn')}
             </h1>
             <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-              Select a project to manage database, auth, storage, and memory. The list is filtered to
-              the projects your platform key can access.
+              {tr('projects.subtitle')}
             </p>
           </div>
           <Link href="/new" className="shrink-0">
             <Button size="sm" className="w-full sm:w-auto">
-              <Plus className="h-3.5 w-3.5" /> New project
+              <Plus className="h-3.5 w-3.5" /> {tr('projects.new')}
             </Button>
           </Link>
         </div>
 
         <div className="grid grid-cols-2 divide-x divide-y divide-border sm:grid-cols-4 sm:divide-y-0">
-          <StatTile label="Total" value={projects.length} icon={Database} />
-          <StatTile label="Ready" value={stats.ready} icon={CheckCircle2} tone="success" />
-          <StatTile label="Pending" value={stats.pending} icon={Clock3} tone="warning" />
-          <StatTile label="Needs attention" value={stats.failed} icon={AlertCircle} tone="danger" />
+          <StatTile label={tr('projects.total')} value={projects.length} icon={Database} />
+          <StatTile label={tr('projects.ready')} value={stats.ready} icon={CheckCircle2} tone="success" />
+          <StatTile label={tr('projects.pending')} value={stats.pending} icon={Clock3} tone="warning" />
+          <StatTile label={tr('projects.failed')} value={stats.failed} icon={AlertCircle} tone="danger" />
         </div>
       </section>
 
@@ -200,7 +201,7 @@ export default function ProjectsPage() {
         <div className="relative min-w-[220px] flex-1">
           <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
-            placeholder="Search projects by name, ref, or description"
+            placeholder={tr('projects.search')}
             value={query}
             onChange={(e) => {
               setQuery(e.target.value);
@@ -217,9 +218,9 @@ export default function ProjectsPage() {
               view === 'grid' ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:text-foreground'
             )}
             aria-pressed={view === 'grid'}
-            aria-label="Grid view"
+            aria-label={tr('projects.gridView')}
           >
-            <LayoutGrid className="h-3.5 w-3.5" /> Grid
+            <LayoutGrid className="h-3.5 w-3.5" /> {tr('projects.grid')}
           </button>
           <button
             onClick={() => setView('list')}
@@ -228,9 +229,9 @@ export default function ProjectsPage() {
               view === 'list' ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:text-foreground'
             )}
             aria-pressed={view === 'list'}
-            aria-label="List view"
+            aria-label={tr('projects.listView')}
           >
-            <List className="h-3.5 w-3.5" /> List
+            <List className="h-3.5 w-3.5" /> {tr('projects.list')}
           </button>
         </div>
       </section>
@@ -262,17 +263,17 @@ export default function ProjectsPage() {
             </div>
             <div>
               <p className="text-sm font-medium">
-                {projects.length === 0 ? 'No projects yet' : 'No projects match your search'}
+                {projects.length === 0 ? tr('projects.emptyTitle') : tr('projects.emptySearchTitle')}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
                 {projects.length === 0
-                  ? 'Create a project configuration to begin.'
-                  : 'Try a different name, ref, or description.'}
+                  ? tr('projects.emptyBody')
+                  : tr('projects.emptySearchBody')}
               </p>
             </div>
             {projects.length === 0 ? (
               <Link href="/new">
-                <Button size="sm">Create your first project</Button>
+                <Button size="sm">{tr('projects.createFirst')}</Button>
               </Link>
             ) : null}
           </CardContent>
@@ -298,12 +299,12 @@ export default function ProjectsPage() {
                     <StatusBadge initStatus={p.initStatus} healthStatus={p.healthStatus} />
                   </div>
                   <p className="mt-3 line-clamp-2 min-h-[32px] text-xs leading-4 text-muted-foreground">
-                    {meaningfulDescription(p) ?? 'No description provided.'}
+                    {meaningfulDescription(p) ?? tr('projects.noDescription')}
                   </p>
                 </div>
                 <div className="flex h-10 items-center justify-between border-t border-border bg-muted/20 px-4">
                   <span className="truncate text-[11px] text-muted-foreground">
-                    schema <span className="font-mono text-foreground/80">{p.schemaName ?? 'public'}</span>
+                    {tr('projects.schema')} <span className="font-mono text-foreground/80">{p.schemaName ?? 'public'}</span>
                   </span>
                   <ArrowRight className="h-3.5 w-3.5 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-foreground" />
                 </div>
@@ -317,10 +318,10 @@ export default function ProjectsPage() {
             <table className="w-full min-w-[760px] text-sm">
               <thead className="border-b border-border bg-muted/30 text-[11px] uppercase tracking-wide text-muted-foreground">
                 <tr>
-                  <th className="px-4 py-2.5 text-left font-medium">Project</th>
-                  <th className="px-4 py-2.5 text-left font-medium">Reference</th>
-                  <th className="px-4 py-2.5 text-left font-medium">Schema</th>
-                  <th className="px-4 py-2.5 text-left font-medium">Status</th>
+                  <th className="px-4 py-2.5 text-left font-medium">{tr('projects.project')}</th>
+                  <th className="px-4 py-2.5 text-left font-medium">{tr('projects.reference')}</th>
+                  <th className="px-4 py-2.5 text-left font-medium">{tr('projects.schema')}</th>
+                  <th className="px-4 py-2.5 text-left font-medium">{tr('projects.status')}</th>
                   <th className="px-4 py-2.5" />
                 </tr>
               </thead>
@@ -334,7 +335,7 @@ export default function ProjectsPage() {
                     <td className="max-w-[340px] px-4 py-3">
                       <div className="truncate font-medium">{p.name}</div>
                       <div className="mt-0.5 truncate text-xs text-muted-foreground">
-                        {meaningfulDescription(p) ?? 'No description provided.'}
+                        {meaningfulDescription(p) ?? tr('projects.noDescription')}
                       </div>
                     </td>
                     <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{p.ref}</td>
@@ -358,8 +359,11 @@ export default function ProjectsPage() {
       {filtered.length > PAGE_SIZE ? (
         <div className="flex flex-col gap-3 rounded-lg border border-border bg-card px-3 py-3 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
           <span>
-            Showing {(safePage - 1) * PAGE_SIZE + 1}-{Math.min(safePage * PAGE_SIZE, filtered.length)} of{' '}
-            {filtered.length}
+            {tr('projects.showing', {
+              start: (safePage - 1) * PAGE_SIZE + 1,
+              end: Math.min(safePage * PAGE_SIZE, filtered.length),
+              total: filtered.length,
+            })}
           </span>
           <div className="flex items-center gap-1">
             <Button
@@ -368,10 +372,10 @@ export default function ProjectsPage() {
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={safePage <= 1}
             >
-              <ChevronLeft className="h-3.5 w-3.5" /> Prev
+              <ChevronLeft className="h-3.5 w-3.5" /> {tr('projects.prev')}
             </Button>
             <span className="px-2">
-              Page {safePage} of {pageCount}
+              {tr('projects.page', { page: safePage, total: pageCount })}
             </span>
             <Button
               size="sm"
@@ -379,7 +383,7 @@ export default function ProjectsPage() {
               onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
               disabled={safePage >= pageCount}
             >
-              Next <ChevronRight className="h-3.5 w-3.5" />
+              {tr('projects.next')} <ChevronRight className="h-3.5 w-3.5" />
             </Button>
           </div>
         </div>

--- a/frontend/apps/studio/src/app/(auth)/layout.tsx
+++ b/frontend/apps/studio/src/app/(auth)/layout.tsx
@@ -1,26 +1,34 @@
+'use client';
+
 import Link from 'next/link';
+import { LanguageToggle, useI18n } from '@/lib/i18n';
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  const { tr } = useI18n();
+  const year = new Date().getFullYear();
   return (
     <div className="grid min-h-screen lg:grid-cols-2">
       <div className="flex flex-col p-8">
-        <Link href="/" className="flex items-center gap-2 text-sm font-semibold tracking-tight">
-          <span className="inline-block h-6 w-6 rounded-md bg-brand" />
-          nubase
-        </Link>
+        <div className="flex items-center justify-between gap-3">
+          <Link href="/" className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+            <span className="inline-block h-6 w-6 rounded-md bg-brand" />
+            nubase
+          </Link>
+          <LanguageToggle />
+        </div>
         <div className="mx-auto flex w-full max-w-sm flex-1 flex-col justify-center">
           {children}
         </div>
         <div className="text-xs text-muted-foreground">
-          &copy; {new Date().getFullYear()} nubase. All rights reserved.
+          {tr('auth.layout.copyright', { year })}
         </div>
       </div>
       <div className="hidden bg-secondary lg:flex lg:flex-col lg:justify-end lg:p-12">
         <blockquote className="space-y-2">
           <p className="text-lg leading-relaxed">
-            “A Postgres-first backend that stays out of the way. We ship features, not glue code.”
+            {tr('auth.layout.quote')}
           </p>
-          <footer className="text-sm text-muted-foreground">— a happy team using nubase</footer>
+          <footer className="text-sm text-muted-foreground">{tr('auth.layout.quoteBy')}</footer>
         </blockquote>
       </div>
     </div>

--- a/frontend/apps/studio/src/app/(auth)/login/page.tsx
+++ b/frontend/apps/studio/src/app/(auth)/login/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { Button, Input, Label } from '@nubase/ui';
 import { API_BASE, apiFetch, type ApiError } from '@/lib/api';
 import { useSession } from '@/lib/session';
+import { useI18n } from '@/lib/i18n';
 
 interface PlatformAuthResponse {
   access_token: string;
@@ -95,6 +96,7 @@ function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const setAuth = useSession((s) => s.setAuth);
+  const { tr } = useI18n();
   const next = safeNext(searchParams.get('next'));
 
   const [email, setEmail] = useState('');
@@ -145,7 +147,7 @@ function LoginContent() {
     if (typeof window === 'undefined') return;
     const params = new URLSearchParams(window.location.search);
     if (params.get('oauth_error')) {
-      setError('Third-party sign in failed. Please try again.');
+      setError(tr('auth.error.thirdParty'));
     }
     const hash = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : '';
     if (!hash) return;
@@ -165,10 +167,10 @@ function LoginContent() {
         });
       })
       .catch(() => {
-        setError('Sign in session could not be established. Please try again.');
+        setError(tr('auth.error.session'));
         setLoading(false);
       });
-  }, [completeLogin]);
+  }, [completeLogin, tr]);
 
   // Google One Tap: auto-detect a signed-in Google account and float the prompt (top-right) so the
   // user can sign in with one click — no inline button next to the password form. Users not signed
@@ -196,7 +198,7 @@ function LoginContent() {
             })
               .then(completeLogin)
               .catch((err) => {
-                setError(parseError(err as ApiError) ?? 'Google sign in failed.');
+                setError(parseError(err as ApiError) ?? tr('auth.error.google'));
                 setLoading(false);
               });
           },
@@ -209,7 +211,7 @@ function LoginContent() {
     return () => {
       cancelled = true;
     };
-  }, [config, completeLogin, pendingEmail]);
+  }, [config, completeLogin, pendingEmail, tr]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -222,13 +224,13 @@ function LoginContent() {
       });
       if (isPending(res)) {
         setPendingEmail(res.email);
-        setNotice(`We sent a 6-digit code to ${res.email}.`);
+        setNotice(tr('auth.confirmEmail.sent', { email: res.email }));
       } else {
         completeLogin(res);
       }
     } catch (err) {
       const e = err as ApiError;
-      setError(parseError(e) ?? 'Sign in failed.');
+      setError(parseError(e) ?? tr('auth.error.signIn'));
     } finally {
       setLoading(false);
     }
@@ -245,7 +247,7 @@ function LoginContent() {
       });
       completeLogin(res);
     } catch (err) {
-      setError(parseError(err as ApiError) ?? 'Verification failed.');
+      setError(parseError(err as ApiError) ?? tr('auth.error.verify'));
       setLoading(false);
     }
   }
@@ -260,7 +262,7 @@ function LoginContent() {
     } catch {
       /* always report sent — no account enumeration */
     }
-    setNotice('A new code is on its way.');
+    setNotice(tr('auth.confirmEmail.resent'));
   }
 
   // One Tap (google_enabled) floats as an overlay, so the inline button row only shows the
@@ -271,14 +273,14 @@ function LoginContent() {
     return (
       <div className="space-y-6">
         <div className="space-y-2">
-          <h1 className="text-2xl font-semibold tracking-tight">Confirm your email</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">{tr('auth.confirmEmail.title')}</h1>
           <p className="text-sm text-muted-foreground">
-            Enter the 6-digit code we emailed to <span className="font-medium">{pendingEmail}</span>.
+            {tr('auth.confirmEmail.body', { email: pendingEmail })}
           </p>
         </div>
         <form onSubmit={onVerify} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="code">Verification code</Label>
+            <Label htmlFor="code">{tr('auth.verificationCode')}</Label>
             <Input
               id="code"
               inputMode="numeric"
@@ -293,7 +295,7 @@ function LoginContent() {
           {notice ? <p className="text-xs text-muted-foreground">{notice}</p> : null}
           {error ? <p className="text-xs text-destructive">{error}</p> : null}
           <Button type="submit" disabled={loading || code.length < 6} className="w-full">
-            {loading ? 'Verifying…' : 'Verify & continue'}
+            {loading ? tr('auth.confirmEmail.verifying') : tr('auth.confirmEmail.verify')}
           </Button>
         </form>
         <button
@@ -301,7 +303,7 @@ function LoginContent() {
           onClick={onResend}
           className="block w-full text-center text-sm text-muted-foreground underline-offset-4 hover:underline"
         >
-          Didn&apos;t get it? Resend code
+          {tr('auth.confirmEmail.resend')}
         </button>
       </div>
     );
@@ -310,10 +312,8 @@ function LoginContent() {
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Sign in to Studio</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage your nubase projects, databases and tenants.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{tr('auth.login.title')}</h1>
+        <p className="text-sm text-muted-foreground">{tr('auth.login.subtitle')}</p>
       </div>
 
       {showOAuth ? (
@@ -329,7 +329,7 @@ function LoginContent() {
                 <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z" />
                 <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z" />
               </svg>
-              Continue with Google
+              {tr('auth.login.google')}
             </a>
           ) : null}
           {config?.github_enabled ? (
@@ -340,12 +340,12 @@ function LoginContent() {
               <svg viewBox="0 0 16 16" aria-hidden="true" className="h-4 w-4 fill-current">
                 <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
               </svg>
-              Continue with GitHub
+              {tr('auth.login.github')}
             </a>
           ) : null}
           <div className="flex items-center gap-3">
             <span className="h-px flex-1 bg-border" />
-            <span className="text-xs text-muted-foreground">or</span>
+            <span className="text-xs text-muted-foreground">{tr('auth.login.or')}</span>
             <span className="h-px flex-1 bg-border" />
           </div>
         </div>
@@ -353,7 +353,7 @@ function LoginContent() {
 
       <form onSubmit={onSubmit} className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
+          <Label htmlFor="email">{tr('auth.email')}</Label>
           <Input
             id="email"
             type="email"
@@ -365,7 +365,7 @@ function LoginContent() {
           />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="password">Password</Label>
+          <Label htmlFor="password">{tr('auth.password')}</Label>
           <Input
             id="password"
             type="password"
@@ -377,13 +377,13 @@ function LoginContent() {
         </div>
         {error ? <p className="text-xs text-destructive">{error}</p> : null}
         <Button type="submit" disabled={loading} className="w-full">
-          {loading ? 'Signing in…' : 'Sign in'}
+          {loading ? tr('auth.login.submitting') : tr('auth.login.submit')}
         </Button>
       </form>
       <p className="text-center text-sm text-muted-foreground">
-        Don&apos;t have an account?{' '}
+        {tr('auth.login.noAccount')}{' '}
         <Link href="/sign-up" className="font-medium text-foreground underline-offset-4 hover:underline">
-          Sign up
+          {tr('auth.login.signUp')}
         </Link>
       </p>
     </div>

--- a/frontend/apps/studio/src/app/(auth)/sign-up/page.tsx
+++ b/frontend/apps/studio/src/app/(auth)/sign-up/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { Button, Input, Label } from '@nubase/ui';
 import { apiFetch, type ApiError } from '@/lib/api';
 import { useSession } from '@/lib/session';
+import { useI18n } from '@/lib/i18n';
 
 interface PlatformAuthResponse {
   access_token: string;
@@ -32,6 +33,7 @@ interface PlatformConfig {
 export default function SignUpPage() {
   const router = useRouter();
   const setAuth = useSession((s) => s.setAuth);
+  const { tr } = useI18n();
 
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
@@ -75,12 +77,12 @@ export default function SignUpPage() {
       });
       if (isPending(res)) {
         setPendingEmail(res.email);
-        setNotice(`We sent a 6-digit code to ${res.email}.`);
+        setNotice(tr('auth.confirmEmail.sent', { email: res.email }));
       } else {
         completeLogin(res);
       }
     } catch (err) {
-      setError(parseError(err as ApiError) ?? 'Sign up failed.');
+      setError(parseError(err as ApiError) ?? tr('auth.error.signUp'));
     } finally {
       setLoading(false);
     }
@@ -97,7 +99,7 @@ export default function SignUpPage() {
       });
       completeLogin(res);
     } catch (err) {
-      setError(parseError(err as ApiError) ?? 'Verification failed.');
+      setError(parseError(err as ApiError) ?? tr('auth.error.verify'));
     } finally {
       setLoading(false);
     }
@@ -111,9 +113,9 @@ export default function SignUpPage() {
         method: 'POST',
         body: { email: pendingEmail },
       });
-      setNotice('A new code is on its way.');
+      setNotice(tr('auth.confirmEmail.resent'));
     } catch {
-      setNotice('A new code is on its way.');
+      setNotice(tr('auth.confirmEmail.resent'));
     }
   }
 
@@ -121,15 +123,12 @@ export default function SignUpPage() {
     return (
       <div className="space-y-4">
         <div className="space-y-2">
-          <h1 className="text-2xl font-semibold tracking-tight">Sign-ups are closed</h1>
-          <p className="text-sm text-muted-foreground">
-            This workspace doesn&apos;t accept public sign-ups. Ask an existing super admin to invite
-            you via the project members or platform users page.
-          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">{tr('auth.signup.closedTitle')}</h1>
+          <p className="text-sm text-muted-foreground">{tr('auth.signup.closedBody')}</p>
         </div>
         <Link href="/login" className="inline-block">
           <Button variant="outline" className="w-full">
-            Back to sign in
+            {tr('auth.signup.back')}
           </Button>
         </Link>
       </div>
@@ -140,14 +139,14 @@ export default function SignUpPage() {
     return (
       <div className="space-y-6">
         <div className="space-y-2">
-          <h1 className="text-2xl font-semibold tracking-tight">Confirm your email</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">{tr('auth.confirmEmail.title')}</h1>
           <p className="text-sm text-muted-foreground">
-            Enter the 6-digit code we emailed to <span className="font-medium">{pendingEmail}</span>.
+            {tr('auth.confirmEmail.body', { email: pendingEmail })}
           </p>
         </div>
         <form onSubmit={onVerify} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="code">Verification code</Label>
+            <Label htmlFor="code">{tr('auth.verificationCode')}</Label>
             <Input
               id="code"
               inputMode="numeric"
@@ -162,7 +161,7 @@ export default function SignUpPage() {
           {notice ? <p className="text-xs text-muted-foreground">{notice}</p> : null}
           {error ? <p className="text-xs text-destructive">{error}</p> : null}
           <Button type="submit" disabled={loading || code.length < 6} className="w-full">
-            {loading ? 'Verifying…' : 'Verify & continue'}
+            {loading ? tr('auth.confirmEmail.verifying') : tr('auth.confirmEmail.verify')}
           </Button>
         </form>
         <button
@@ -170,7 +169,7 @@ export default function SignUpPage() {
           onClick={onResend}
           className="text-center text-sm text-muted-foreground underline-offset-4 hover:underline"
         >
-          Didn&apos;t get it? Resend code
+          {tr('auth.confirmEmail.resend')}
         </button>
       </div>
     );
@@ -179,24 +178,22 @@ export default function SignUpPage() {
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Create your Studio account</h1>
-        <p className="text-sm text-muted-foreground">
-          Platform admin access to manage all your nubase projects.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{tr('auth.signup.title')}</h1>
+        <p className="text-sm text-muted-foreground">{tr('auth.signup.subtitle')}</p>
       </div>
       <form onSubmit={onSubmit} className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="fullName">Full name</Label>
+          <Label htmlFor="fullName">{tr('auth.fullName')}</Label>
           <Input
             id="fullName"
             value={fullName}
             onChange={(e) => setFullName(e.target.value)}
             autoComplete="name"
-            placeholder="Optional"
+            placeholder={tr('auth.optional')}
           />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
+          <Label htmlFor="email">{tr('auth.email')}</Label>
           <Input
             id="email"
             type="email"
@@ -207,7 +204,7 @@ export default function SignUpPage() {
           />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="password">Password</Label>
+          <Label htmlFor="password">{tr('auth.password')}</Label>
           <Input
             id="password"
             type="password"
@@ -217,17 +214,17 @@ export default function SignUpPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
-          <p className="text-xs text-muted-foreground">At least 8 characters.</p>
+          <p className="text-xs text-muted-foreground">{tr('auth.signup.passwordHelp')}</p>
         </div>
         {error ? <p className="text-xs text-destructive">{error}</p> : null}
         <Button type="submit" disabled={loading} className="w-full">
-          {loading ? 'Creating account…' : 'Create account'}
+          {loading ? tr('auth.signup.submitting') : tr('auth.signup.submit')}
         </Button>
       </form>
       <p className="text-center text-sm text-muted-foreground">
-        Already have an account?{' '}
+        {tr('auth.signup.hasAccount')}{' '}
         <Link href="/login" className="font-medium text-foreground underline-offset-4 hover:underline">
-          Sign in
+          {tr('auth.signup.signIn')}
         </Link>
       </p>
     </div>

--- a/frontend/apps/studio/src/app/project/[ref]/auth/_components/sub-nav.test.tsx
+++ b/frontend/apps/studio/src/app/project/[ref]/auth/_components/sub-nav.test.tsx
@@ -4,8 +4,8 @@ import { AuthSubNav } from './sub-nav';
 
 // Stub next/link to a plain anchor for jsdom.
 vi.mock('next/link', () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
+  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
   ),
 }));
 

--- a/frontend/apps/studio/src/app/providers.tsx
+++ b/frontend/apps/studio/src/app/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
 import { ToastProvider } from '@nubase/ui';
+import { I18nProvider } from '@/lib/i18n';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [client] = useState(
@@ -16,7 +17,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={client}>
-      <ToastProvider>{children}</ToastProvider>
+      <I18nProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </I18nProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/apps/studio/src/components/theme-toggle.tsx
+++ b/frontend/apps/studio/src/components/theme-toggle.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { Moon, Sun } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 const STORAGE_KEY = 'nubase.theme';
 
@@ -14,6 +15,7 @@ function applyTheme(t: Theme) {
 }
 
 export function ThemeToggle({ className }: { className?: string }) {
+  const { tr } = useI18n();
   const [theme, setTheme] = useState<Theme>('light');
 
   useEffect(() => {
@@ -34,12 +36,14 @@ export function ThemeToggle({ className }: { className?: string }) {
     }
   }
 
+  const label = theme === 'dark' ? tr('theme.light') : tr('theme.dark');
+
   return (
     <button
       onClick={toggle}
       className={'rounded-md border border-transparent p-1.5 text-muted-foreground transition-colors hover:border-border hover:bg-accent hover:text-foreground ' + (className ?? '')}
-      aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-      title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+      aria-label={label}
+      title={label}
     >
       {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
     </button>

--- a/frontend/apps/studio/src/components/user-menu.tsx
+++ b/frontend/apps/studio/src/components/user-menu.tsx
@@ -6,11 +6,13 @@ import { useRouter } from 'next/navigation';
 import { LogOut, User, FolderGit2, ShieldCheck, Settings } from 'lucide-react';
 import { cn } from '@nubase/ui';
 import { useSession, isSuperAdmin } from '@/lib/session';
+import { LanguageToggle, useI18n } from '@/lib/i18n';
 import { ThemeToggle } from './theme-toggle';
 
 export function UserMenu({ className }: { className?: string }) {
   const router = useRouter();
   const { user, signOut } = useSession();
+  const { tr } = useI18n();
   const superAdmin = isSuperAdmin(user);
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -44,6 +46,7 @@ export function UserMenu({ className }: { className?: string }) {
 
   return (
     <div className={cn('flex items-center gap-1.5', className)}>
+      <LanguageToggle />
       <ThemeToggle />
       <div ref={wrapRef} className="relative">
       <button
@@ -51,7 +54,7 @@ export function UserMenu({ className }: { className?: string }) {
         className="flex h-8 w-8 items-center justify-center rounded-full bg-secondary text-[11px] font-bold uppercase shadow-sm transition-opacity hover:opacity-90"
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label="Account menu"
+        aria-label={tr('user.menu')}
         title={user.email}
       >
         {initials}
@@ -63,22 +66,22 @@ export function UserMenu({ className }: { className?: string }) {
           className="absolute right-0 z-50 mt-2 w-60 overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-xl shadow-slate-950/10"
         >
           <div className="border-b border-border bg-muted/35 px-3 py-2.5 text-xs">
-            <div className="font-semibold">{user.fullName ?? 'Signed in'}</div>
+            <div className="font-semibold">{user.fullName ?? tr('user.signedIn')}</div>
             <div className="truncate text-muted-foreground">{user.email}</div>
           </div>
           <MenuLink href="/projects" icon={FolderGit2} onClick={() => setOpen(false)}>
-            All projects
+            {tr('shell.nav.allProjects')}
           </MenuLink>
           <MenuLink href="/account" icon={User} onClick={() => setOpen(false)}>
-            Account
+            {tr('shell.nav.account')}
           </MenuLink>
           {superAdmin ? (
             <>
               <MenuLink href="/admin/users" icon={ShieldCheck} onClick={() => setOpen(false)}>
-                Platform users
+                {tr('user.platformUsers')}
               </MenuLink>
               <MenuLink href="/admin/settings" icon={Settings} onClick={() => setOpen(false)}>
-                Platform settings
+                {tr('user.platformSettings')}
               </MenuLink>
             </>
           ) : null}
@@ -87,7 +90,7 @@ export function UserMenu({ className }: { className?: string }) {
             className="flex w-full items-center gap-2 border-t border-border px-3 py-2.5 text-left text-sm font-medium text-destructive hover:bg-accent"
             role="menuitem"
           >
-            <LogOut className="h-4 w-4" /> Sign out
+            <LogOut className="h-4 w-4" /> {tr('user.signOut')}
           </button>
         </div>
       ) : null}

--- a/frontend/apps/studio/src/components/workspace-shell.tsx
+++ b/frontend/apps/studio/src/components/workspace-shell.tsx
@@ -31,10 +31,11 @@ import { cn } from '@nubase/ui';
 import { useSession, isProjectReady } from '@/lib/session';
 import { apiFetch } from '@/lib/api';
 import { useProjectRef } from '@/lib/route-params';
+import { type MessageKey, useI18n } from '@/lib/i18n';
 import { UserMenu } from './user-menu';
 
 interface NavItem {
-  label: string;
+  labelKey: MessageKey;
   href: string;
   icon: React.ComponentType<{ className?: string }>;
   /** Exact match (no startsWith) — used for the workspace root link so it doesn't match /projects/foo. */
@@ -42,26 +43,26 @@ interface NavItem {
 }
 
 const WORKSPACE_NAV: NavItem[] = [
-  { label: 'All projects', href: '/projects', icon: FolderGit2 },
-  { label: 'New project', href: '/new', icon: Plus },
-  { label: 'Account', href: '/account', icon: User },
+  { labelKey: 'shell.nav.allProjects', href: '/projects', icon: FolderGit2 },
+  { labelKey: 'shell.nav.newProject', href: '/new', icon: Plus },
+  { labelKey: 'shell.nav.account', href: '/account', icon: User },
 ];
 
 function projectNav(ref: string): NavItem[] {
   return [
-    { label: 'Home', href: `/project/${ref}`, icon: Home, exact: true },
-    { label: 'Table Editor', href: `/project/${ref}/editor`, icon: Table2 },
-    { label: 'SQL Editor', href: `/project/${ref}/sql`, icon: Terminal },
-    { label: 'Authentication', href: `/project/${ref}/auth`, icon: Users },
-    { label: 'Storage', href: `/project/${ref}/storage`, icon: HardDrive },
-    { label: 'Assets', href: `/project/${ref}/assets`, icon: FileBox },
-    { label: 'Memory', href: `/project/${ref}/memory`, icon: Brain },
-    { label: 'AI Gateway', href: `/project/${ref}/ai-gateway`, icon: Bot },
-    { label: 'Functions', href: `/project/${ref}/functions`, icon: CloudCog },
-    { label: 'Cron', href: `/project/${ref}/cron`, icon: CalendarClock },
-    { label: 'Connect Agent', href: `/project/${ref}/connect-agent`, icon: Cable },
-    { label: 'Logs', href: `/project/${ref}/logs`, icon: Activity },
-    { label: 'Settings', href: `/project/${ref}/settings`, icon: Settings },
+    { labelKey: 'shell.nav.home', href: `/project/${ref}`, icon: Home, exact: true },
+    { labelKey: 'shell.nav.tableEditor', href: `/project/${ref}/editor`, icon: Table2 },
+    { labelKey: 'shell.nav.sqlEditor', href: `/project/${ref}/sql`, icon: Terminal },
+    { labelKey: 'shell.nav.authentication', href: `/project/${ref}/auth`, icon: Users },
+    { labelKey: 'shell.nav.storage', href: `/project/${ref}/storage`, icon: HardDrive },
+    { labelKey: 'shell.nav.assets', href: `/project/${ref}/assets`, icon: FileBox },
+    { labelKey: 'shell.nav.memory', href: `/project/${ref}/memory`, icon: Brain },
+    { labelKey: 'shell.nav.aiGateway', href: `/project/${ref}/ai-gateway`, icon: Bot },
+    { labelKey: 'shell.nav.functions', href: `/project/${ref}/functions`, icon: CloudCog },
+    { labelKey: 'shell.nav.cron', href: `/project/${ref}/cron`, icon: CalendarClock },
+    { labelKey: 'shell.nav.connectAgent', href: `/project/${ref}/connect-agent`, icon: Cable },
+    { labelKey: 'shell.nav.logs', href: `/project/${ref}/logs`, icon: Activity },
+    { labelKey: 'shell.nav.settings', href: `/project/${ref}/settings`, icon: Settings },
   ];
 }
 
@@ -84,6 +85,7 @@ export function WorkspaceShell({
   projectRef?: string;
   children: React.ReactNode;
 }) {
+  const { tr } = useI18n();
   const router = useRouter();
   const pathname = usePathname();
   const project = useSession((s) => s.project);
@@ -193,7 +195,7 @@ export function WorkspaceShell({
             <>
               {!collapsed && (
                 <div className="mb-1 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
-                  Project
+                  {tr('shell.section.project')}
                 </div>
               )}
               {projectNav(activeProjectRef).map((item) => (
@@ -201,14 +203,14 @@ export function WorkspaceShell({
               ))}
               {!collapsed && (
                 <div className="mb-1 mt-5 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
-                  Workspace
+                  {tr('shell.section.workspace')}
                 </div>
               )}
             </>
           ) : (
             !collapsed && (
               <div className="mb-1 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
-                Workspace
+                {tr('shell.section.workspace')}
               </div>
             )
           )}
@@ -227,14 +229,14 @@ export function WorkspaceShell({
           )}
         >
           {!collapsed && (
-            <span className="text-[11px] font-medium text-muted-foreground">v0.1 · Self-hosted</span>
+            <span className="text-[11px] font-medium text-muted-foreground">{tr('shell.version')}</span>
           )}
           <button
             type="button"
             onClick={toggle}
             className="rounded-md border border-transparent p-1.5 text-muted-foreground transition-colors hover:border-border hover:bg-accent hover:text-foreground"
-            title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            title={collapsed ? tr('shell.expand') : tr('shell.collapse')}
+            aria-label={collapsed ? tr('shell.expand') : tr('shell.collapse')}
           >
             {collapsed ? (
               <PanelLeftOpen className="h-3.5 w-3.5" />
@@ -263,8 +265,7 @@ export function WorkspaceShell({
           <div className="flex items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-6 py-2 text-xs text-amber-700 dark:text-amber-300">
             <AlertTriangle className="h-3.5 w-3.5" />
             <span>
-              Project is <strong className="font-semibold">{project?.initStatus?.toLowerCase()}</strong> —
-              the underlying database is not provisioned yet. Database, Auth and Storage pages will be empty.
+              {tr('shell.projectWarning', { status: project?.initStatus?.toLowerCase() ?? 'pending' })}
             </span>
           </div>
         ) : null}
@@ -295,6 +296,7 @@ function ProjectSwitcher({
 }) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
+  const { tr } = useI18n();
 
   useEffect(() => {
     function onDocClick(e: MouseEvent) {
@@ -326,9 +328,9 @@ function ProjectSwitcher({
           className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 font-semibold text-foreground transition-colors hover:bg-accent"
         >
           <FolderGit2 className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <span className="hidden truncate sm:inline">Workspace</span>
+          <span className="hidden truncate sm:inline">{tr('shell.workspace')}</span>
           <span className="rounded-full border border-border bg-background px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
-            Local
+            {tr('shell.local')}
           </span>
         </Link>
         <span className="text-lg font-light text-muted-foreground/70">/</span>
@@ -347,7 +349,7 @@ function ProjectSwitcher({
         <div className="hidden min-w-0 items-center gap-2 md:flex">
           <span className="truncate font-mono text-[13px] font-semibold text-foreground">main</span>
           <span className="rounded-full border border-emerald-600/25 bg-emerald-500/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
-            Ready
+            {tr('shell.ready')}
           </span>
         </div>
       </div>
@@ -359,7 +361,7 @@ function ProjectSwitcher({
         >
           <div className="border-b border-border bg-muted/35 px-3 py-2.5">
             <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
-              Switch project
+              {tr('shell.switchProject')}
             </div>
             <div className="mt-0.5 truncate text-xs text-muted-foreground">{activeProjectRef}</div>
           </div>
@@ -391,7 +393,7 @@ function ProjectSwitcher({
               );
             })
           ) : (
-            <div className="px-3 py-3 text-xs text-muted-foreground">No projects available.</div>
+            <div className="px-3 py-3 text-xs text-muted-foreground">{tr('shell.noProjects')}</div>
           )}
         </div>
       ) : null}
@@ -408,14 +410,16 @@ function SidebarLink({
   pathname: string;
   collapsed: boolean;
 }) {
+  const { tr } = useI18n();
   const Icon = item.icon;
   const active = item.exact ? pathname === item.href : pathname === item.href || pathname.startsWith(item.href + '/');
+  const label = tr(item.labelKey);
   return (
     <Link
       href={item.href}
       // When collapsed, center the icon and drop the label. Native title attribute gives
       // free hover tooltips so users don't lose their bearings in icon-only mode.
-      title={collapsed ? item.label : undefined}
+      title={collapsed ? label : undefined}
       className={cn(
         'flex items-center rounded-lg text-sm font-medium transition-colors',
         collapsed
@@ -427,7 +431,7 @@ function SidebarLink({
       )}
     >
       <Icon className="h-4 w-4 shrink-0" />
-      {!collapsed && <span className="truncate">{item.label}</span>}
+      {!collapsed && <span className="truncate">{label}</span>}
     </Link>
   );
 }

--- a/frontend/apps/studio/src/lib/i18n.test.tsx
+++ b/frontend/apps/studio/src/lib/i18n.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { I18nProvider, LanguageToggle, t, useI18n } from './i18n';
+
+function Probe() {
+  const { locale, setLocale, tr } = useI18n();
+  return (
+    <div>
+      <p>{locale}</p>
+      <p>{tr('auth.login.title')}</p>
+      <button onClick={() => setLocale('zh-CN')}>set zh</button>
+    </div>
+  );
+}
+
+describe('studio i18n', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      clear: () => store.clear(),
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+      removeItem: (key: string) => store.delete(key),
+    });
+    window.localStorage.clear();
+    document.documentElement.lang = '';
+  });
+
+  it('translates dictionary keys with interpolation', () => {
+    expect(t('en', 'shell.projectWarning', { status: 'pending' })).toContain('Project is pending');
+    expect(t('zh-CN', 'shell.projectWarning', { status: 'pending' })).toContain('项目状态为 pending');
+  });
+
+  it('defaults to English and persists language changes', () => {
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('en')).toBeInTheDocument();
+    expect(screen.getByText('Sign in to Studio')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('set zh'));
+
+    expect(screen.getByText('zh-CN')).toBeInTheDocument();
+    expect(screen.getByText('登录 Studio')).toBeInTheDocument();
+    expect(window.localStorage.getItem('nubase.studio.locale')).toBe('zh-CN');
+    expect(document.documentElement.lang).toBe('zh-CN');
+  });
+
+  it('renders a language toggle that switches between English and Chinese', () => {
+    render(
+      <I18nProvider>
+        <LanguageToggle />
+        <Probe />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch language to Chinese' }));
+
+    expect(screen.getByText('zh-CN')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '切换语言为英文' })).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/studio/src/lib/i18n.tsx
+++ b/frontend/apps/studio/src/lib/i18n.tsx
@@ -1,0 +1,420 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { Languages } from 'lucide-react';
+
+export const LOCALE_KEY = 'nubase.studio.locale';
+
+export type Locale = 'en' | 'zh-CN';
+
+const messages = {
+  en: {
+    'language.switchToChinese': 'Switch language to Chinese',
+    'language.switchToEnglish': 'Switch language to English',
+    'language.english': 'English',
+    'language.chinese': '中文',
+
+    'auth.layout.copyright': '© {year} nubase. All rights reserved.',
+    'auth.layout.quote': '“A Postgres-first backend that stays out of the way. We ship features, not glue code.”',
+    'auth.layout.quoteBy': '— a happy team using nubase',
+    'auth.email': 'Email',
+    'auth.password': 'Password',
+    'auth.fullName': 'Full name',
+    'auth.optional': 'Optional',
+    'auth.verificationCode': 'Verification code',
+    'auth.confirmEmail.title': 'Confirm your email',
+    'auth.confirmEmail.body': 'Enter the 6-digit code we emailed to {email}.',
+    'auth.confirmEmail.sent': 'We sent a 6-digit code to {email}.',
+    'auth.confirmEmail.resent': 'A new code is on its way.',
+    'auth.confirmEmail.verify': 'Verify & continue',
+    'auth.confirmEmail.verifying': 'Verifying…',
+    'auth.confirmEmail.resend': "Didn't get it? Resend code",
+    'auth.error.thirdParty': 'Third-party sign in failed. Please try again.',
+    'auth.error.session': 'Sign in session could not be established. Please try again.',
+    'auth.error.google': 'Google sign in failed.',
+    'auth.error.signIn': 'Sign in failed.',
+    'auth.error.signUp': 'Sign up failed.',
+    'auth.error.verify': 'Verification failed.',
+    'auth.login.title': 'Sign in to Studio',
+    'auth.login.subtitle': 'Manage your nubase projects, databases and tenants.',
+    'auth.login.google': 'Continue with Google',
+    'auth.login.github': 'Continue with GitHub',
+    'auth.login.or': 'or',
+    'auth.login.submit': 'Sign in',
+    'auth.login.submitting': 'Signing in…',
+    'auth.login.noAccount': "Don't have an account?",
+    'auth.login.signUp': 'Sign up',
+    'auth.signup.closedTitle': 'Sign-ups are closed',
+    'auth.signup.closedBody': "This workspace doesn't accept public sign-ups. Ask an existing super admin to invite you via the project members or platform users page.",
+    'auth.signup.back': 'Back to sign in',
+    'auth.signup.title': 'Create your Studio account',
+    'auth.signup.subtitle': 'Platform admin access to manage all your nubase projects.',
+    'auth.signup.passwordHelp': 'At least 8 characters.',
+    'auth.signup.submit': 'Create account',
+    'auth.signup.submitting': 'Creating account…',
+    'auth.signup.hasAccount': 'Already have an account?',
+    'auth.signup.signIn': 'Sign in',
+
+    'shell.nav.allProjects': 'All projects',
+    'shell.nav.newProject': 'New project',
+    'shell.nav.account': 'Account',
+    'shell.nav.home': 'Home',
+    'shell.nav.tableEditor': 'Table Editor',
+    'shell.nav.sqlEditor': 'SQL Editor',
+    'shell.nav.authentication': 'Authentication',
+    'shell.nav.storage': 'Storage',
+    'shell.nav.assets': 'Assets',
+    'shell.nav.memory': 'Memory',
+    'shell.nav.aiGateway': 'AI Gateway',
+    'shell.nav.functions': 'Functions',
+    'shell.nav.cron': 'Cron',
+    'shell.nav.connectAgent': 'Connect Agent',
+    'shell.nav.logs': 'Logs',
+    'shell.nav.settings': 'Settings',
+    'shell.section.project': 'Project',
+    'shell.section.workspace': 'Workspace',
+    'shell.version': 'v0.1 · Self-hosted',
+    'shell.expand': 'Expand sidebar',
+    'shell.collapse': 'Collapse sidebar',
+    'shell.workspace': 'Workspace',
+    'shell.local': 'Local',
+    'shell.ready': 'Ready',
+    'shell.switchProject': 'Switch project',
+    'shell.noProjects': 'No projects available.',
+    'shell.projectWarning': 'Project is {status} — the underlying database is not provisioned yet. Database, Auth and Storage pages will be empty.',
+
+    'theme.light': 'Switch to light theme',
+    'theme.dark': 'Switch to dark theme',
+    'user.menu': 'Account menu',
+    'user.signedIn': 'Signed in',
+    'user.platformUsers': 'Platform users',
+    'user.platformSettings': 'Platform settings',
+    'user.signOut': 'Sign out',
+
+    'projects.scope': 'workspace',
+    'projects.superAdmin': 'super admin',
+    'projects.titleAll': 'All projects',
+    'projects.titleOwn': 'Your projects',
+    'projects.subtitle': 'Select a project to manage database, auth, storage, and memory. The list is filtered to the projects your platform key can access.',
+    'projects.new': 'New project',
+    'projects.total': 'Total',
+    'projects.ready': 'Ready',
+    'projects.pending': 'Pending',
+    'projects.failed': 'Needs attention',
+    'projects.search': 'Search projects by name, ref, or description',
+    'projects.gridView': 'Grid view',
+    'projects.listView': 'List view',
+    'projects.grid': 'Grid',
+    'projects.list': 'List',
+    'projects.loadError': 'Failed to load projects.',
+    'projects.emptyTitle': 'No projects yet',
+    'projects.emptySearchTitle': 'No projects match your search',
+    'projects.emptyBody': 'Create a project configuration to begin.',
+    'projects.emptySearchBody': 'Try a different name, ref, or description.',
+    'projects.createFirst': 'Create your first project',
+    'projects.noDescription': 'No description provided.',
+    'projects.schema': 'schema',
+    'projects.project': 'Project',
+    'projects.reference': 'Reference',
+    'projects.status': 'Status',
+    'projects.showing': 'Showing {start}-{end} of {total}',
+    'projects.prev': 'Prev',
+    'projects.next': 'Next',
+    'projects.page': 'Page {page} of {total}',
+
+    'newProject.title': 'New project',
+    'newProject.subtitle': 'Save a project configuration. The Postgres database is provisioned automatically on the next screen.',
+    'newProject.name': 'Project name',
+    'newProject.namePlaceholder': 'My CRM',
+    'newProject.nameHelp': 'Shown in the dashboard.',
+    'newProject.ref': 'Reference',
+    'newProject.refHelp': 'Lower-case, digits and underscores. Used as the API path segment, database name and JWT ref claim. Cannot be changed later.',
+    'newProject.description': 'Description (optional)',
+    'newProject.descriptionPlaceholder': 'Internal CRM data',
+    'newProject.region': 'Region',
+    'newProject.regionHelp': 'Visual only for now — self-hosted nubase runs against a single Postgres host.',
+    'newProject.cancel': 'Cancel',
+    'newProject.create': 'Create project',
+    'newProject.creating': 'Creating…',
+    'newProject.created': 'Project created',
+    'newProject.initializing': 'Initializing the database…',
+    'newProject.createFailed': 'Create failed',
+    'newProject.failed': 'Failed to create project.',
+
+    'account.title': 'Account',
+    'account.subtitle': 'Your platform user profile.',
+    'account.profile': 'Profile',
+    'account.profileDescription': 'Identity used when calling the platform API.',
+    'account.fullName': 'Full name',
+    'account.role': 'Role',
+    'account.userId': 'User ID',
+    'account.roleSuper': 'You can see every project in this workspace.',
+    'account.roleUser': 'You can only see projects you own or were invited to.',
+    'account.security': 'Security',
+    'account.securityDescription': "Change your password. We email a confirmation code to verify it's you.",
+    'account.currentPassword': 'Current password',
+    'account.newPassword': 'New password',
+    'account.passwordOtpSent': 'We emailed you a 6-digit confirmation code.',
+    'account.passwordOtpFailed': 'Could not start the password change.',
+    'account.passwordUpdated': 'Password updated.',
+    'account.passwordChangeFailed': 'Could not change the password.',
+    'account.sendingCode': 'Sending code…',
+    'account.continue': 'Continue',
+    'account.confirmationCode': 'Confirmation code',
+    'account.updating': 'Updating…',
+    'account.changePassword': 'Change password',
+    'account.cancel': 'Cancel',
+  },
+  'zh-CN': {
+    'language.switchToChinese': '切换语言为中文',
+    'language.switchToEnglish': '切换语言为英文',
+    'language.english': 'English',
+    'language.chinese': '中文',
+
+    'auth.layout.copyright': '© {year} nubase。保留所有权利。',
+    'auth.layout.quote': '“Postgres-first 后端平台，不打扰业务开发。我们交付功能，而不是胶水代码。”',
+    'auth.layout.quoteBy': '— 一个正在使用 nubase 的团队',
+    'auth.email': '邮箱',
+    'auth.password': '密码',
+    'auth.fullName': '姓名',
+    'auth.optional': '选填',
+    'auth.verificationCode': '验证码',
+    'auth.confirmEmail.title': '确认邮箱',
+    'auth.confirmEmail.body': '输入发送到 {email} 的 6 位验证码。',
+    'auth.confirmEmail.sent': '我们已向 {email} 发送 6 位验证码。',
+    'auth.confirmEmail.resent': '新的验证码已发送。',
+    'auth.confirmEmail.verify': '验证并继续',
+    'auth.confirmEmail.verifying': '正在验证…',
+    'auth.confirmEmail.resend': '没有收到？重新发送验证码',
+    'auth.error.thirdParty': '第三方登录失败，请重试。',
+    'auth.error.session': '无法建立登录会话，请重试。',
+    'auth.error.google': 'Google 登录失败。',
+    'auth.error.signIn': '登录失败。',
+    'auth.error.signUp': '注册失败。',
+    'auth.error.verify': '验证失败。',
+    'auth.login.title': '登录 Studio',
+    'auth.login.subtitle': '管理你的 nubase 项目、数据库和租户。',
+    'auth.login.google': '使用 Google 继续',
+    'auth.login.github': '使用 GitHub 继续',
+    'auth.login.or': '或',
+    'auth.login.submit': '登录',
+    'auth.login.submitting': '正在登录…',
+    'auth.login.noAccount': '还没有账号？',
+    'auth.login.signUp': '注册',
+    'auth.signup.closedTitle': '注册已关闭',
+    'auth.signup.closedBody': '当前工作区不接受公开注册。请联系已有 super admin 通过项目成员或平台用户页面邀请你。',
+    'auth.signup.back': '返回登录',
+    'auth.signup.title': '创建 Studio 账号',
+    'auth.signup.subtitle': '用于管理所有 nubase 项目的平台管理员账号。',
+    'auth.signup.passwordHelp': '至少 8 个字符。',
+    'auth.signup.submit': '创建账号',
+    'auth.signup.submitting': '正在创建账号…',
+    'auth.signup.hasAccount': '已经有账号？',
+    'auth.signup.signIn': '登录',
+
+    'shell.nav.allProjects': '全部项目',
+    'shell.nav.newProject': '新建项目',
+    'shell.nav.account': '账号',
+    'shell.nav.home': '首页',
+    'shell.nav.tableEditor': '表编辑器',
+    'shell.nav.sqlEditor': 'SQL 编辑器',
+    'shell.nav.authentication': '认证',
+    'shell.nav.storage': '存储',
+    'shell.nav.assets': '静态资源',
+    'shell.nav.memory': '记忆',
+    'shell.nav.aiGateway': 'AI 网关',
+    'shell.nav.functions': '函数',
+    'shell.nav.cron': '定时任务',
+    'shell.nav.connectAgent': '连接 Agent',
+    'shell.nav.logs': '日志',
+    'shell.nav.settings': '设置',
+    'shell.section.project': '项目',
+    'shell.section.workspace': '工作区',
+    'shell.version': 'v0.1 · 自托管',
+    'shell.expand': '展开侧边栏',
+    'shell.collapse': '收起侧边栏',
+    'shell.workspace': '工作区',
+    'shell.local': '本地',
+    'shell.ready': '就绪',
+    'shell.switchProject': '切换项目',
+    'shell.noProjects': '暂无可用项目。',
+    'shell.projectWarning': '项目状态为 {status}，底层数据库尚未完成开通。数据库、认证和存储页面将为空。',
+
+    'theme.light': '切换为浅色主题',
+    'theme.dark': '切换为深色主题',
+    'user.menu': '账号菜单',
+    'user.signedIn': '已登录',
+    'user.platformUsers': '平台用户',
+    'user.platformSettings': '平台设置',
+    'user.signOut': '退出登录',
+
+    'projects.scope': '工作区',
+    'projects.superAdmin': 'super admin',
+    'projects.titleAll': '全部项目',
+    'projects.titleOwn': '我的项目',
+    'projects.subtitle': '选择一个项目来管理数据库、认证、存储和记忆。列表会按当前平台密钥权限过滤。',
+    'projects.new': '新建项目',
+    'projects.total': '总数',
+    'projects.ready': '就绪',
+    'projects.pending': '等待中',
+    'projects.failed': '需要处理',
+    'projects.search': '按名称、ref 或描述搜索项目',
+    'projects.gridView': '网格视图',
+    'projects.listView': '列表视图',
+    'projects.grid': '网格',
+    'projects.list': '列表',
+    'projects.loadError': '加载项目失败。',
+    'projects.emptyTitle': '暂无项目',
+    'projects.emptySearchTitle': '没有匹配的项目',
+    'projects.emptyBody': '创建一个项目配置即可开始。',
+    'projects.emptySearchBody': '尝试其他名称、ref 或描述。',
+    'projects.createFirst': '创建第一个项目',
+    'projects.noDescription': '未提供描述。',
+    'projects.schema': 'schema',
+    'projects.project': '项目',
+    'projects.reference': '引用标识',
+    'projects.status': '状态',
+    'projects.showing': '显示第 {start}-{end} 条，共 {total} 条',
+    'projects.prev': '上一页',
+    'projects.next': '下一页',
+    'projects.page': '第 {page} 页，共 {total} 页',
+
+    'newProject.title': '新建项目',
+    'newProject.subtitle': '保存项目配置。Postgres 数据库会在下一页自动开通。',
+    'newProject.name': '项目名称',
+    'newProject.namePlaceholder': '我的 CRM',
+    'newProject.nameHelp': '显示在仪表盘中的名称。',
+    'newProject.ref': '引用标识',
+    'newProject.refHelp': '小写字母、数字和下划线。用作 API 路径片段、数据库名称和 JWT ref claim。创建后不可修改。',
+    'newProject.description': '描述（选填）',
+    'newProject.descriptionPlaceholder': '内部 CRM 数据',
+    'newProject.region': '区域',
+    'newProject.regionHelp': '当前仅用于展示。自托管 nubase 使用单个 Postgres 主机。',
+    'newProject.cancel': '取消',
+    'newProject.create': '创建项目',
+    'newProject.creating': '正在创建…',
+    'newProject.created': '项目已创建',
+    'newProject.initializing': '正在初始化数据库…',
+    'newProject.createFailed': '创建失败',
+    'newProject.failed': '创建项目失败。',
+
+    'account.title': '账号',
+    'account.subtitle': '你的平台用户资料。',
+    'account.profile': '资料',
+    'account.profileDescription': '调用平台 API 时使用的身份。',
+    'account.fullName': '姓名',
+    'account.role': '角色',
+    'account.userId': '用户 ID',
+    'account.roleSuper': '你可以查看当前工作区中的所有项目。',
+    'account.roleUser': '你只能查看自己拥有或受邀加入的项目。',
+    'account.security': '安全',
+    'account.securityDescription': '修改密码。我们会通过邮件发送验证码来确认是你本人操作。',
+    'account.currentPassword': '当前密码',
+    'account.newPassword': '新密码',
+    'account.passwordOtpSent': '我们已向你发送 6 位确认验证码。',
+    'account.passwordOtpFailed': '无法开始密码修改流程。',
+    'account.passwordUpdated': '密码已更新。',
+    'account.passwordChangeFailed': '无法修改密码。',
+    'account.sendingCode': '正在发送验证码…',
+    'account.continue': '继续',
+    'account.confirmationCode': '确认验证码',
+    'account.updating': '正在更新…',
+    'account.changePassword': '修改密码',
+    'account.cancel': '取消',
+  },
+} as const;
+
+export type MessageKey = keyof typeof messages.en;
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  tr: (key: MessageKey, values?: Record<string, string | number>) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+function isLocale(value: string | null): value is Locale {
+  return value === 'en' || value === 'zh-CN';
+}
+
+export function t(locale: Locale, key: MessageKey, values: Record<string, string | number> = {}) {
+  let text: string = messages[locale][key] ?? messages.en[key] ?? key;
+  for (const [name, value] of Object.entries(values)) {
+    text = text.replaceAll(`{${name}}`, String(value));
+  }
+  return text;
+}
+
+function initialLocale(): Locale {
+  if (typeof window === 'undefined') return 'en';
+  const stored = safeGetStoredLocale();
+  if (isLocale(stored)) return stored;
+  const browser = window.navigator.language;
+  return browser.toLowerCase().startsWith('zh') ? 'zh-CN' : 'en';
+}
+
+function safeGetStoredLocale() {
+  try {
+    return window.localStorage?.getItem(LOCALE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>('en');
+
+  useEffect(() => {
+    setLocaleState(initialLocale());
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  const value = useMemo<I18nContextValue>(() => {
+    const setLocale = (next: Locale) => {
+      setLocaleState(next);
+      try {
+        window.localStorage?.setItem(LOCALE_KEY, next);
+      } catch {
+        // 私密模式或禁用存储时，语言选择仍在当前会话内生效。
+      }
+    };
+    return {
+      locale,
+      setLocale,
+      tr: (key, values) => t(locale, key, values),
+    };
+  }, [locale]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const value = useContext(I18nContext);
+  if (!value) throw new Error('useI18n must be used inside I18nProvider');
+  return value;
+}
+
+export function LanguageToggle({ className }: { className?: string }) {
+  const { locale, setLocale, tr } = useI18n();
+  const next = locale === 'en' ? 'zh-CN' : 'en';
+  const label = locale === 'en' ? tr('language.switchToChinese') : tr('language.switchToEnglish');
+  return (
+    <button
+      type="button"
+      onClick={() => setLocale(next)}
+      className={
+        'inline-flex items-center gap-1.5 rounded-md border border-transparent px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-border hover:bg-accent hover:text-foreground ' +
+        (className ?? '')
+      }
+      aria-label={label}
+      title={label}
+    >
+      <Languages className="h-3.5 w-3.5" />
+      <span>{locale === 'en' ? tr('language.chinese') : tr('language.english')}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a small Studio i18n layer with English and Simplified Chinese dictionaries.
- Add a persisted language toggle on auth pages and in the app header.
- Localize the auth flow, workspace shell, project list, new project form, and account/security entry pages.
- Add focused i18n tests and fix the AuthSubNav test mock so it preserves Link props.

## Notes

This keeps the first PR scoped to the Studio frame and main entry flows. Deep project modules can migrate their remaining strings incrementally through the same `useI18n()` API.

## Validation

- `corepack pnpm --filter @nubase/studio test src/lib/i18n.test.tsx`
- `corepack pnpm --filter @nubase/studio typecheck`
- `corepack pnpm --filter @nubase/studio test`
- `corepack pnpm --filter @nubase/studio build`
