### PR TITLE
fix(mcp): require service_role for executeSql and initDatabase

### DIFF
--- a/src/main/java/ai/nubase/mcp/tools/DatabaseMcpTools.java
+++ b/src/main/java/ai/nubase/mcp/tools/DatabaseMcpTools.java
@@ -187,9 +187,13 @@ public class DatabaseMcpTools {
     @Tool(description = "Executes raw SQL query in the database. " +
             "Parameter: sqlQuery - The SQL query to execute (DDL, DML, or SELECT). " +
             "Supports multiple SQL statements separated by semicolons. " +
-            "Returns individual results for each statement.")
+            "Returns individual results for each statement. Requires service_role MCP apikey.")
     public Object executeSql(String sqlQuery) {
         try {
+            Map<String, Object> guard = requireServiceRole("execute SQL");
+            if (guard != null) {
+                return guard;
+            }
             log.info("MCP_Tool_USED- executeSql called");
             SqlRisk risk = sqlRiskClassifier.classify(sqlQuery);
             DatabaseConfig dbConfig = MultiTenancyContext.getDatabaseConfig();
@@ -264,9 +268,13 @@ public class DatabaseMcpTools {
      */
     @Tool(description = "Initialize the physical database for the current app. " +
             "Checks if the database has already been initialized and performs initialization if needed. " +
-            "No parameters required - uses the current database context.")
+            "No parameters required - uses the current database context. Requires service_role MCP apikey.")
     public Object initDatabase() {
         try {
+            Map<String, Object> guard = requireServiceRole("initialize database");
+            if (guard != null) {
+                return guard;
+            }
             log.info("MCP_Tool_USED - initDatabase called");
             // Get current database configuration from context
             DatabaseConfig dbConfig = MultiTenancyContext.getDatabaseConfig();
@@ -337,6 +345,18 @@ public class DatabaseMcpTools {
                     "error", "Failed to initialize database: " + e.getMessage()
             );
         }
+    }
+
+    /**
+     * Align with other MCP admin tools and HTTP {@code /auth/v1/admin/sql/execute}:
+     * raw SQL and physical DB init run with owner-level JDBC and must not be callable
+     * with anon/authenticated project apikeys.
+     */
+    private Map<String, Object> requireServiceRole(String action) {
+        if (!MultiTenancyContext.isServiceRole()) {
+            return Map.of("success", false, "error", "Cannot " + action + ": service_role MCP apikey is required");
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/ai/nubase/mcp/tools/DatabaseMcpToolsTest.java
+++ b/src/test/java/ai/nubase/mcp/tools/DatabaseMcpToolsTest.java
@@ -1,6 +1,8 @@
 package ai.nubase.mcp.tools;
 
+import ai.nubase.common.context.MultiTenancyContext;
 import ai.nubase.mcp.safety.SqlRiskClassifier;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +17,43 @@ class DatabaseMcpToolsTest {
     @BeforeEach
     void setUp() {
         tools = new DatabaseMcpTools(null, null, null, null, new SqlRiskClassifier());
+    }
+
+    @AfterEach
+    void tearDown() {
+        MultiTenancyContext.clear();
+    }
+
+    @Test
+    void executeSqlWithServiceRoleStillRequiresInitializedDatabase() {
+        MultiTenancyContext.setContext(MultiTenancyContext.ContextData.builder()
+                .appCode("demo")
+                .schemaName("public")
+                .jwtSecret("test-secret-key-at-least-32-bytes-long")
+                .serviceRole(true)
+                .build());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response = (Map<String, Object>) tools.executeSql("select 1");
+
+        assertThat(response).containsEntry("error", "Database context not found, please ensure the database is initialized");
+        assertThat(response).doesNotContainKey("results");
+    }
+
+    @Test
+    void initDatabaseWithServiceRoleStillRequiresDatabaseContext() {
+        MultiTenancyContext.setContext(MultiTenancyContext.ContextData.builder()
+                .appCode("demo")
+                .schemaName("public")
+                .jwtSecret("test-secret-key-at-least-32-bytes-long")
+                .serviceRole(true)
+                .build());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response = (Map<String, Object>) tools.initDatabase();
+
+        assertThat(response).containsEntry("success", false);
+        assertThat(response.get("error")).asString().contains("Database context not found");
     }
 
     @Test

--- a/src/test/java/ai/nubase/mcp/tools/RemoteAdminMcpToolsTest.java
+++ b/src/test/java/ai/nubase/mcp/tools/RemoteAdminMcpToolsTest.java
@@ -2,7 +2,10 @@ package ai.nubase.mcp.tools;
 
 import ai.nubase.auth.service.AdminService;
 import ai.nubase.auth.service.BucketService;
+import ai.nubase.auth.service.DatabaseInitService;
+import ai.nubase.auth.service.SqlExecutionService;
 import ai.nubase.common.context.MultiTenancyContext;
+import ai.nubase.mcp.safety.SqlRiskClassifier;
 import ai.nubase.cron.service.ScheduledJobAdminService;
 import ai.nubase.deploy.service.AppDeploymentRollbackService;
 import ai.nubase.deploy.service.AppDeploymentService;
@@ -74,6 +77,28 @@ class RemoteAdminMcpToolsTest {
         assertThat(result).isInstanceOf(Map.class);
         assertThat(asMap(result)).containsEntry("success", false);
         verifyNoInteractions(service);
+    }
+
+    @Test
+    void executeSqlRequiresServiceRole() {
+        SqlExecutionService sqlExecutionService = mock(SqlExecutionService.class);
+        Object result = new DatabaseMcpTools(null, sqlExecutionService, null, null, new SqlRiskClassifier())
+                .executeSql("select 1");
+
+        assertThat(result).isInstanceOf(Map.class);
+        assertThat(asMap(result)).containsEntry("success", false);
+        verifyNoInteractions(sqlExecutionService);
+    }
+
+    @Test
+    void initDatabaseRequiresServiceRole() {
+        DatabaseInitService databaseInitService = mock(DatabaseInitService.class);
+        Object result = new DatabaseMcpTools(null, null, null, databaseInitService, new SqlRiskClassifier())
+                .initDatabase();
+
+        assertThat(result).isInstanceOf(Map.class);
+        assertThat(asMap(result)).containsEntry("success", false);
+        verifyNoInteractions(databaseInitService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 为远程 HTTP MCP 的 `executeSql` 和 `initDatabase` 增加 `service_role` apikey 校验
- 与现有 MCP 管理类工具（`AuthMcpTools`、`StorageMcpTools` 等）及 HTTP `/auth/v1/admin/sql/execute` 的权限模型对齐
- 更新 `@Tool` 描述，标明需要 `service_role` MCP apikey

## Why
`SqlExecutionService` 与 `DatabaseInitService` 的注释均要求仅 `service_role` 可访问，但此前远程 `/mcp` 允许 `anon` / `authenticated` 项目 apikey 调用相同 owner 级 JDBC 路径，存在权限缺口。

## Breaking change
`initDatabase` 的只读状态查询（`alreadyInitialized`）现在也需要 `service_role`；此前任意有效 apikey 均可调用。

## Test plan
- [x] `mvn test -Dtest=RemoteAdminMcpToolsTest,DatabaseMcpToolsTest`（11 tests passed）
- [x] 非 service_role 调用返回 `{ success: false }` 且不触发底层 Service
- [x] service_role 通过守卫后仍要求已初始化的 `DatabaseConfig`
- [x] `executeSqlDryRun` 行为不变（只读风险预览）