### PR TITLE
fix(auth): HTML-escape OAuth callback error pages

### DIFF
--- a/src/main/java/ai/nubase/auth/controller/AuthController.java
+++ b/src/main/java/ai/nubase/auth/controller/AuthController.java
@@ -20,6 +20,7 @@ import ai.nubase.auth.dto.request.SignUpRequest;
 import ai.nubase.auth.dto.request.VerifyRequest;
 import ai.nubase.auth.util.TokenGenerator;
 import ai.nubase.common.context.MultiTenancyContext;
+import ai.nubase.common.util.HtmlEscape;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -220,7 +221,7 @@ public class AuthController {
             try {
                 Resource resource = resourceLoader.getResource("classpath:templates/verify-error.html");
                 String htmlContent = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-                htmlContent = htmlContent.replace("{{ERROR_MESSAGE}}", e.getMessage());
+                htmlContent = htmlContent.replace("{{ERROR_MESSAGE}}", HtmlEscape.escape(e.getMessage()));
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                         .contentType(MediaType.TEXT_HTML)
                         .body(htmlContent);
@@ -317,7 +318,7 @@ public class AuthController {
             try {
                 Resource resource = resourceLoader.getResource("classpath:templates/oauth-config-error.html");
                 String htmlContent = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-                htmlContent = htmlContent.replace("{{ERROR_MESSAGE}}", e.getMessage());
+                htmlContent = htmlContent.replace("{{ERROR_MESSAGE}}", HtmlEscape.escape(e.getMessage()));
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                         .contentType(MediaType.TEXT_HTML)
                         .body(htmlContent);
@@ -346,7 +347,7 @@ public class AuthController {
         if (error != null) {
             String errorHtml = String.format(
                     "<html><body><h1>Authentication Failed</h1><p>%s: %s</p></body></html>",
-                    error, errorDescription
+                    HtmlEscape.escape(error), HtmlEscape.escape(errorDescription)
             );
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .contentType(MediaType.TEXT_HTML)
@@ -399,7 +400,7 @@ public class AuthController {
                 }
                 return ResponseEntity.ok()
                         .contentType(MediaType.TEXT_HTML)
-                        .body("<html><body><p>code=" + authCode + "</p></body></html>");
+                        .body("<html><body><p>code=" + HtmlEscape.escape(authCode) + "</p></body></html>");
             }
 
             // Manual identity linking: attach the resolved identity to the existing user.
@@ -449,7 +450,7 @@ public class AuthController {
         } catch (Exception e) {
             String errorHtml = String.format(
                     "<html><body><h1>Authentication Failed</h1><p>%s</p></body></html>",
-                    e.getMessage()
+                    HtmlEscape.escape(e.getMessage())
             );
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .contentType(MediaType.TEXT_HTML)

--- a/src/main/java/ai/nubase/common/util/HtmlEscape.java
+++ b/src/main/java/ai/nubase/common/util/HtmlEscape.java
@@ -1,0 +1,17 @@
+package ai.nubase.common.util;
+
+import org.springframework.web.util.HtmlUtils;
+
+/**
+ * HTML text-node escaping for small, hand-built HTML responses (OAuth error pages).
+ * Prevents reflected XSS when query parameters or exception messages are echoed into HTML.
+ */
+public final class HtmlEscape {
+
+    private HtmlEscape() {}
+
+    /** Returns an empty string for null so callers can format without extra null checks. */
+    public static String escape(String value) {
+        return value == null ? "" : HtmlUtils.htmlEscape(value);
+    }
+}

--- a/src/test/java/ai/nubase/auth/controller/AuthControllerCallbackTest.java
+++ b/src/test/java/ai/nubase/auth/controller/AuthControllerCallbackTest.java
@@ -1,0 +1,62 @@
+package ai.nubase.auth.controller;
+
+import ai.nubase.auth.service.AuthService;
+import ai.nubase.auth.service.IdTokenService;
+import ai.nubase.auth.service.OAuthService;
+import ai.nubase.auth.service.OAuthStateService;
+import ai.nubase.auth.service.OtpService;
+import ai.nubase.auth.service.PkceService;
+import ai.nubase.auth.service.RedirectUrlValidator;
+import ai.nubase.auth.util.TokenGenerator;
+import ai.nubase.common.config.AuthConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static ai.nubase.test.ControllerTestSupport.OBJECT_MAPPER;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.mock;
+
+class AuthControllerCallbackTest {
+
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        mvc = MockMvcBuilders.standaloneSetup(new AuthController(
+                mock(AuthService.class),
+                mock(OtpService.class),
+                mock(OAuthService.class),
+                mock(OAuthStateService.class),
+                mock(PkceService.class),
+                mock(IdTokenService.class),
+                mock(RedirectUrlValidator.class),
+                mock(org.springframework.core.io.ResourceLoader.class),
+                mock(TokenGenerator.class),
+                mock(AuthConfig.class)
+        ))
+                .setMessageConverters(
+                        new MappingJackson2HttpMessageConverter(OBJECT_MAPPER),
+                        new StringHttpMessageConverter())
+                .build();
+    }
+
+    @Test
+    void oauthCallbackErrorParamsAreHtmlEscaped() throws Exception {
+        mvc.perform(get("/auth/v1/callback")
+                        .param("code", "dummy")
+                        .param("error", "<img src=x onerror=alert(1)>")
+                        .param("error_description", "<script>alert(1)</script>"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString("&lt;img src=x onerror=alert(1)&gt;")))
+                .andExpect(content().string(containsString("&lt;script&gt;alert(1)&lt;/script&gt;")))
+                .andExpect(content().string(not(containsString("<script>alert(1)</script>"))));
+    }
+}

--- a/src/test/java/ai/nubase/common/util/HtmlEscapeTest.java
+++ b/src/test/java/ai/nubase/common/util/HtmlEscapeTest.java
@@ -1,0 +1,19 @@
+package ai.nubase.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HtmlEscapeTest {
+
+    @Test
+    void escapesScriptTags() {
+        assertThat(HtmlEscape.escape("<script>alert(1)</script>"))
+                .isEqualTo("&lt;script&gt;alert(1)&lt;/script&gt;");
+    }
+
+    @Test
+    void nullReturnsEmptyString() {
+        assertThat(HtmlEscape.escape(null)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `HtmlEscape` 工具类，对写入 HTML 文本节点的动态内容进行转义
- OAuth `/auth/v1/callback` 的 `error` / `error_description` 及异常消息不再原样拼入 HTML
- 同步修复 `verify-error` / `oauth-config-error` 模板中的 `{{ERROR_MESSAGE}}` 替换路径

## Why
攻击者可构造 `/auth/v1/callback?error=<script>...` 触发反射型 XSS；异常 `getMessage()` 若含特殊字符也存在同类风险。

## Test plan
- [x] `mvn test -Dtest=HtmlEscapeTest,AuthControllerCallbackTest`（3 tests passed）
- [x] 回调 error 参数在响应中显示为 `&lt;script&gt;...` 而非可执行标签

## Note
本 PR 不改动 OAuth 成功页 token 暴露问题（`postMessage('*')`），可作为后续独立 PR 处理。