### PR TITLE
fix(gateway): mask Claude API keys in logs and request files

### DIFF
--- a/src/main/java/ai/nubase/ai/gateway/service/ClaudeGatewayService.java
+++ b/src/main/java/ai/nubase/ai/gateway/service/ClaudeGatewayService.java
@@ -3,6 +3,7 @@ package ai.nubase.ai.gateway.service;
 import ai.nubase.ai.gateway.dto.ApiUsageRecord;
 import ai.nubase.ai.gateway.dto.TokenUsage;
 import ai.nubase.common.config.AnthropicConfig;
+import ai.nubase.common.util.ApiKeyLogMask;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
@@ -148,7 +149,7 @@ public class ClaudeGatewayService {
         long startTime = System.currentTimeMillis();
         String requestId = UUID.randomUUID().toString();
 
-        log.info("📤 [{}] GET {} - API Key: {}", requestId, path, (clientApiKey));
+        log.info("📤 [{}] GET {} - API Key: {}", requestId, path, ApiKeyLogMask.mask(clientApiKey));
 
         Request.Builder requestBuilder = new Request.Builder()
                 .url(url)
@@ -199,7 +200,7 @@ public class ClaudeGatewayService {
                         trackApiUsage(clientApiKey, requestId, null, path, "GET",
                                 response.code(), responseBody, duration, headers, null);
 
-                        requestLogService.logRequest(requestId, (clientApiKey), "GET", path,
+                        requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "GET", path,
                                 null, headers, null, response.code(), responseBody, duration,
                                 TokenUsage.empty(), null);
 
@@ -211,7 +212,7 @@ public class ClaudeGatewayService {
                 trackApiUsage(clientApiKey, requestId, null, path, "GET",
                         response.code(), responseBody, duration, headers, null);
 
-                requestLogService.logRequest(requestId, (clientApiKey), "GET", path,
+                requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "GET", path,
                         null, headers, null, response.code(), responseBody, duration,
                         TokenUsage.empty(), null);
 
@@ -237,7 +238,7 @@ public class ClaudeGatewayService {
                     trackApiUsage(clientApiKey, requestId, null, path, "GET",
                             500, null, duration, headers, e.getMessage());
 
-                    requestLogService.logRequest(requestId, (clientApiKey), "GET", path,
+                    requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "GET", path,
                             null, headers, null, 500, null, duration,
                             TokenUsage.empty(), e.getMessage());
 
@@ -357,7 +358,7 @@ public class ClaudeGatewayService {
         String requestId = UUID.randomUUID().toString();
 
         log.info("agent_log [{}] POST {} - 模型: {}, API Key: {}, 上游: {}",
-                requestId, path, model, (clientApiKey), upstream.name);
+                requestId, path, model, ApiKeyLogMask.mask(clientApiKey), upstream.name);
         log.info("上游配置: baseUrl={}, timeout={}ms, maxInputTokens={}",
                 upstream.baseUrl, upstream.timeout, upstream.maxInputTokens);
         String requestBodyLog = requestBody.length() > 200 ? requestBody.substring(0, 200) + "..." : requestBody;
@@ -429,7 +430,7 @@ public class ClaudeGatewayService {
                         trackApiUsage(clientApiKey, requestId, model, path, "POST",
                                 response.code(), responseBody, duration, headers, null);
 
-                        requestLogService.logRequest(requestId, (clientApiKey), "POST", path,
+                        requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "POST", path,
                                 model, headers, requestBody, response.code(), responseBody, duration,
                                 tokenUsage, null);
 
@@ -441,7 +442,7 @@ public class ClaudeGatewayService {
                 trackApiUsage(clientApiKey, requestId, model, path, "POST",
                         response.code(), responseBody, duration, headers, null);
 
-                requestLogService.logRequest(requestId, (clientApiKey), "POST", path,
+                requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "POST", path,
                         model, headers, requestBody, response.code(), responseBody, duration,
                         tokenUsage, null);
 
@@ -467,7 +468,7 @@ public class ClaudeGatewayService {
                     trackApiUsage(clientApiKey, requestId, model, path, "POST",
                             500, null, duration, headers, e.getMessage());
 
-                    requestLogService.logRequest(requestId, (clientApiKey), "POST", path,
+                    requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "POST", path,
                             model, headers, requestBody, 500, null, duration,
                             TokenUsage.empty(), e.getMessage());
 
@@ -500,7 +501,7 @@ public class ClaudeGatewayService {
         log.info("🔢 转发 Count Tokens 请求到 Claude API");
         log.info("请求ID: {}", requestId);
         log.info("URL: {}", url);
-        log.info("客户端 API Key: {}", (clientApiKey));
+        log.info("客户端 API Key: {}", ApiKeyLogMask.mask(clientApiKey));
         if (headers != null && !headers.isEmpty()) {
             log.info("请求头: {}", headers);
         }
@@ -652,7 +653,7 @@ public class ClaudeGatewayService {
                     response.code(), null, duration, headers,
                     response.isSuccessful() ? null : responseBody);
 
-            requestLogService.logRequest(requestId, clientApiKey, "POST", path,
+            requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "POST", path,
                     null, headers,
                     "{\"_multipart\":true,\"filename\":\"" + filename.replace("\"", "\\\"")
                             + "\",\"size\":" + file.getSize() + "}",
@@ -712,7 +713,7 @@ public class ClaudeGatewayService {
                 downstream.setContentType("application/json");
                 trackApiUsage(clientApiKey, requestId, null, path, "GET",
                         status, null, duration, headers, errorBody);
-                requestLogService.logRequest(requestId, clientApiKey, "GET", path,
+                requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "GET", path,
                         null, headers, null, status, errorBody, duration,
                         TokenUsage.empty(), errorBody);
                 downstream.getOutputStream().write(errorBody.getBytes(java.nio.charset.StandardCharsets.UTF_8));
@@ -746,7 +747,7 @@ public class ClaudeGatewayService {
 
             trackApiUsage(clientApiKey, requestId, null, path, "GET",
                     status, null, duration, headers, null);
-            requestLogService.logRequest(requestId, clientApiKey, "GET", path,
+            requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "GET", path,
                     null, headers, null, status, "{\"_binary\":true}", duration,
                     TokenUsage.empty(), null);
         } finally {
@@ -830,7 +831,7 @@ public class ClaudeGatewayService {
                     response.code(), null, duration, headers,
                     response.isSuccessful() ? null : responseBody);
 
-            requestLogService.logRequest(requestId, clientApiKey, upperMethod, path,
+            requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), upperMethod, path,
                     null, headers, expectsBody ? requestBody : null,
                     response.code(), responseBody, duration,
                     TokenUsage.empty(),
@@ -937,7 +938,7 @@ public class ClaudeGatewayService {
 
         log.info("========================================");
         log.info("agent_log [{}] POST {} (stream) - 模型: {}, API Key: {}, 上游: {}",
-                requestId, path, model, clientApiKey, primaryUpstream.name);
+                requestId, path, model, ApiKeyLogMask.mask(clientApiKey), primaryUpstream.name);
         log.info("上游配置: baseUrl={}, timeout={}ms, maxInputTokens={}",
                 primaryUpstream.baseUrl, primaryUpstream.timeout, primaryUpstream.maxInputTokens);
         String requestBodyLog = requestBody.length() > 200 ? requestBody.substring(0, 200) + "..." : requestBody;
@@ -1202,7 +1203,7 @@ public class ClaudeGatewayService {
                         trackApiUsageWithTokens(clientApiKey, requestId, model, path, "POST",
                                 200, finalUsage, duration, ttft, headers);
 
-                        requestLogService.logRequest(requestId, (clientApiKey), "POST", path,
+                        requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "POST", path,
                                 model, headers, originalRequestBody, 200,
                                 "{\"type\":\"message_stream\",\"status\":\"completed\"}",
                                 duration, finalUsage, null);
@@ -1216,7 +1217,7 @@ public class ClaudeGatewayService {
                         trackApiUsage(clientApiKey, requestId, model, path, "POST",
                                 statusCode, null, duration, headers, errorMsg);
 
-                        requestLogService.logRequest(requestId, (clientApiKey), "POST", path,
+                        requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "POST", path,
                                 model, headers, originalRequestBody, statusCode, errorBody, duration,
                                 TokenUsage.empty(), errorMsg);
                     }
@@ -1305,7 +1306,7 @@ public class ClaudeGatewayService {
             trackApiUsage(clientApiKey, requestId, model, path, "POST",
                     408, null, duration, headers, "请求超时");
 
-            requestLogService.logRequest(requestId, (clientApiKey), "POST", path,
+            requestLogService.logRequest(requestId, ApiKeyLogMask.mask(clientApiKey), "POST", path,
                     model, headers, originalRequestBody, 408, null, duration,
                     TokenUsage.empty(), "请求超时");
 

--- a/src/main/java/ai/nubase/common/util/ApiKeyLogMask.java
+++ b/src/main/java/ai/nubase/common/util/ApiKeyLogMask.java
@@ -1,0 +1,16 @@
+package ai.nubase.common.util;
+
+/**
+ * 网关与审计日志中的 API Key 脱敏，保留首尾各 4 位便于排障关联。
+ */
+public final class ApiKeyLogMask {
+
+    private ApiKeyLogMask() {}
+
+    public static String mask(String apiKey) {
+        if (apiKey == null || apiKey.length() <= 8) {
+            return "***";
+        }
+        return apiKey.substring(0, 4) + "..." + apiKey.substring(apiKey.length() - 4);
+    }
+}

--- a/src/test/java/ai/nubase/common/util/ApiKeyLogMaskTest.java
+++ b/src/test/java/ai/nubase/common/util/ApiKeyLogMaskTest.java
@@ -1,0 +1,20 @@
+package ai.nubase.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiKeyLogMaskTest {
+
+    @Test
+    void mask_longKeyShowsPrefixAndSuffix() {
+        assertThat(ApiKeyLogMask.mask("nbk_demo_abcdefghijklmnopqrstuvwxyz"))
+                .isEqualTo("nbk_...wxyz");
+    }
+
+    @Test
+    void mask_shortOrNullReturnsPlaceholder() {
+        assertThat(ApiKeyLogMask.mask(null)).isEqualTo("***");
+        assertThat(ApiKeyLogMask.mask("short")).isEqualTo("***");
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `ApiKeyLogMask` 工具类，日志中 API Key 仅保留首尾各 4 位
- `ClaudeGatewayService` 所有 `log.info` 与 `ApiRequestLogService.logRequest` 入参改为脱敏后的 key
- 计费/用量追踪（`trackApiUsage`）仍使用原始 key，行为不变

## Why
OpenAI 网关路径已对 client API Key 做掩码，且 `ApiRequestLogService` 文档约定传入「掩码后的 key」；Claude 路径此前写入明文，会泄露到应用日志与 `ai-gateway-logs` 目录。

## Test plan
- [x] `mvn test -Dtest=ApiKeyLogMaskTest`