### PR TITLE
fix(mcp): redact sensitive headers in MCP request logs

### DIFF
--- a/src/main/java/ai/nubase/common/multitenancy/UnifiedMultiTenancyFilter.java
+++ b/src/main/java/ai/nubase/common/multitenancy/UnifiedMultiTenancyFilter.java
@@ -7,6 +7,7 @@ import ai.nubase.auth.repository.UserRepository;
 import ai.nubase.auth.service.JwtSecretService;
 import ai.nubase.auth.service.OAuthStateService;
 import ai.nubase.common.context.MultiTenancyContext;
+import ai.nubase.common.util.SensitiveHeaderLogMask;
 import ai.nubase.common.enums.DatabaseInitStatus;
 import ai.nubase.common.enums.Role;
 import ai.nubase.postgrest.multidb.DatabaseConfig;
@@ -492,18 +493,9 @@ public class UnifiedMultiTenancyFilter extends OncePerRequestFilter {
         byte[] content = request.getContentAsByteArray();
         String body = content.length > 0 ? new String(content, StandardCharsets.UTF_8) : null;
 
-        MCP_LOG.info("MCP Request: method={}, uri={}, headers={}, body={}", request.getMethod(), request.getRequestURI(), getHeaders(request), body);
+        MCP_LOG.info("MCP Request: method={}, uri={}, headers={}, body={}",
+                request.getMethod(), request.getRequestURI(), SensitiveHeaderLogMask.collectMasked(request), body);
 
-    }
-
-    private Map<String, String> getHeaders(HttpServletRequest request) {
-        Map<String, String> headers = new HashMap<>();
-        Enumeration<String> headerNames = request.getHeaderNames();
-        while (headerNames.hasMoreElements()) {
-            String name = headerNames.nextElement();
-            headers.put(name, request.getHeader(name));
-        }
-        return headers;
     }
 
     private void logResponse(ContentCachingResponseWrapper response, long duration) {

--- a/src/main/java/ai/nubase/common/util/SensitiveHeaderLogMask.java
+++ b/src/main/java/ai/nubase/common/util/SensitiveHeaderLogMask.java
@@ -1,0 +1,63 @@
+package ai.nubase.common.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * MCP/HTTP 请求日志用 header 脱敏：保留 header 名便于排障，敏感值仅留首尾片段。
+ */
+public final class SensitiveHeaderLogMask {
+
+    private static final Set<String> SENSITIVE_NAMES = Set.of(
+            "apikey",
+            "authorization",
+            "cookie",
+            "proxy-authorization",
+            "x-api-key",
+            "x-auth-token"
+    );
+
+    private SensitiveHeaderLogMask() {}
+
+    /**
+     * 从请求收集 header 并脱敏，专用于日志输出，不影响实际鉴权链路。
+     */
+    public static Map<String, String> collectMasked(HttpServletRequest request) {
+        if (request == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> headers = new LinkedHashMap<>();
+        Enumeration<String> names = request.getHeaderNames();
+        if (names == null) {
+            return headers;
+        }
+        while (names.hasMoreElements()) {
+            String name = names.nextElement();
+            headers.put(name, maskValue(name, request.getHeader(name)));
+        }
+        return headers;
+    }
+
+    static String maskValue(String headerName, String value) {
+        if (!isSensitive(headerName)) {
+            return value;
+        }
+        if (value == null || value.isBlank()) {
+            return value;
+        }
+        if (value.length() <= 8) {
+            return "***";
+        }
+        return value.substring(0, 4) + "..." + value.substring(value.length() - 4);
+    }
+
+    private static boolean isSensitive(String headerName) {
+        return headerName != null && SENSITIVE_NAMES.contains(headerName.toLowerCase(Locale.ROOT));
+    }
+}

--- a/src/test/java/ai/nubase/common/util/SensitiveHeaderLogMaskTest.java
+++ b/src/test/java/ai/nubase/common/util/SensitiveHeaderLogMaskTest.java
@@ -1,0 +1,30 @@
+package ai.nubase.common.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SensitiveHeaderLogMaskTest {
+
+    @Test
+    void collectMasked_redactsApikeyAndAuthorization() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("apikey", "eyJhbGciOiJIUzI1NiJ9.service_role_payload");
+        request.addHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.user_jwt");
+        request.addHeader("Content-Type", "application/json");
+
+        var masked = SensitiveHeaderLogMask.collectMasked(request);
+
+        assertThat(masked.get("apikey")).isEqualTo("eyJh...load");
+        assertThat(masked.get("Authorization")).isEqualTo("Bear..._jwt");
+        assertThat(masked.get("Content-Type")).isEqualTo("application/json");
+    }
+
+    @Test
+    void maskValue_shortSensitiveHeaderReturnsPlaceholder() {
+        assertThat(SensitiveHeaderLogMask.maskValue("apikey", "short")).isEqualTo("***");
+        assertThat(SensitiveHeaderLogMask.maskValue("Content-Type", "application/json"))
+                .isEqualTo("application/json");
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `SensitiveHeaderLogMask`，对 `apikey`、`Authorization`、`cookie` 等敏感 header 做掩码
- `UnifiedMultiTenancyFilter` 的 `McpLogger` 请求日志改用脱敏后的 header map
- 鉴权逻辑不变，仅影响日志与 `MCP_FILE` 落盘内容

## Why
MCP 请求日志此前会原样记录 `apikey`（含 `service_role` JWT），生产环境 `McpLogger` 为 INFO 级别并写入文件，存在凭证泄露风险。

## Test plan
- [x] `mvn test -Dtest=SensitiveHeaderLogMaskTest`