### PR TITLE
fix(postgrest): apply per-tenant db_max_rows on GET/RPC reads

### DIFF
--- a/src/main/java/ai/nubase/postgrest/query/PostgrestRowLimitResolver.java
+++ b/src/main/java/ai/nubase/postgrest/query/PostgrestRowLimitResolver.java
@@ -1,0 +1,66 @@
+package ai.nubase.postgrest.query;
+
+import ai.nubase.postgrest.api.RangeHeader;
+
+/**
+ * 将 PostgREST 的 {@code db-max-rows} 与客户端 Range/limit 合并为 SQL 分页参数。
+ *
+ * <p>规则（对齐 PostgREST GET 读路径）：
+ * <ul>
+ *   <li>无 Range 且配置了 {@code db_max_rows} → 默认 {@code LIMIT db_max_rows}</li>
+ *   <li>Range 请求行数超过上限 → 截断到 {@code db_max_rows}</li>
+ *   <li>开区间 Range（如 {@code items=10-}）→ 从 offset 起最多取 {@code db_max_rows} 行</li>
+ *   <li>{@code db_max_rows} 为 null 或 ≤0 → 不施加服务端默认上限（无 Range 时不 LIMIT）</li>
+ * </ul>
+ */
+public final class PostgrestRowLimitResolver {
+
+    public record ResolvedPagination(Long offset, Long limit) {}
+
+    private PostgrestRowLimitResolver() {}
+
+    public static ResolvedPagination resolve(RangeHeader range, Integer dbMaxRows) {
+        Integer cap = effectiveCap(dbMaxRows);
+        if (range == null) {
+            return cap == null
+                    ? new ResolvedPagination(null, null)
+                    : new ResolvedPagination(0L, cap.longValue());
+        }
+        if (cap == null) {
+            return legacyClientRange(range);
+        }
+        return cappedRange(range, cap.longValue());
+    }
+
+    /** 无服务端 cap 时保持 QueryPlanner 原有 Range 语义。 */
+    private static ResolvedPagination legacyClientRange(RangeHeader range) {
+        Long offset = range.getStart();
+        Long limit = null;
+        if (range.getEnd() != null && range.getStart() != null) {
+            limit = range.getEnd() - range.getStart() + 1;
+        }
+        return new ResolvedPagination(offset, limit);
+    }
+
+    private static ResolvedPagination cappedRange(RangeHeader range, long cap) {
+        Long offset = range.getStart();
+        long resolvedOffset = offset != null ? offset : 0L;
+
+        if (range.getEnd() == null) {
+            return new ResolvedPagination(resolvedOffset, cap);
+        }
+        if (range.getStart() == null) {
+            long requested = range.getEnd() + 1;
+            return new ResolvedPagination(null, Math.min(requested, cap));
+        }
+        long requested = range.getEnd() - range.getStart() + 1;
+        return new ResolvedPagination(resolvedOffset, Math.min(requested, cap));
+    }
+
+    private static Integer effectiveCap(Integer dbMaxRows) {
+        if (dbMaxRows == null || dbMaxRows <= 0) {
+            return null;
+        }
+        return dbMaxRows;
+    }
+}

--- a/src/main/java/ai/nubase/postgrest/query/QueryPlanner.java
+++ b/src/main/java/ai/nubase/postgrest/query/QueryPlanner.java
@@ -95,16 +95,7 @@ public class QueryPlanner {
                 .collect(Collectors.toList()));
         }
 
-        // Handle Range header for pagination
-        if (request.getRange() != null) {
-            RangeHeader range = request.getRange();
-            if (range.getStart() != null) {
-                builder.offset(range.getStart());
-            }
-            if (range.getEnd() != null && range.getStart() != null) {
-                builder.limit(range.getEnd() - range.getStart() + 1);
-            }
-        }
+        applyReadPagination(builder, request.getRange());
 
         // Handle filters (for filtering function results)
         if (request.getFilters() != null && !request.getFilters().isEmpty()) {
@@ -192,16 +183,24 @@ public class QueryPlanner {
                 .collect(Collectors.toList()));
         }
 
-        // Handle Range header for pagination
-        if (request.getRange() != null) {
-            RangeHeader range = request.getRange();
-            if (range.getStart() != null) {
-                builder.offset(range.getStart());
-            }
-            if (range.getEnd() != null && range.getStart() != null) {
-                builder.limit(range.getEnd() - range.getStart() + 1);
-            }
+        applyReadPagination(builder, request.getRange());
+    }
+
+    private void applyReadPagination(QueryPlan.QueryPlanBuilder builder, RangeHeader range) {
+        Integer dbMaxRows = resolveDbMaxRows();
+        PostgrestRowLimitResolver.ResolvedPagination pagination =
+                PostgrestRowLimitResolver.resolve(range, dbMaxRows);
+        if (pagination.offset() != null) {
+            builder.offset(pagination.offset());
         }
+        if (pagination.limit() != null) {
+            builder.limit(pagination.limit());
+        }
+    }
+
+    private Integer resolveDbMaxRows() {
+        var config = MultiTenancyContext.getDatabaseConfig();
+        return config != null ? config.getDbMaxRows() : null;
     }
 
     private void buildInsertPlan(QueryPlan.QueryPlanBuilder builder, ApiRequest request) {

--- a/src/test/java/ai/nubase/postgrest/query/PostgrestRowLimitResolverTest.java
+++ b/src/test/java/ai/nubase/postgrest/query/PostgrestRowLimitResolverTest.java
@@ -1,0 +1,55 @@
+package ai.nubase.postgrest.query;
+
+import ai.nubase.postgrest.api.RangeHeader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgrestRowLimitResolverTest {
+
+    @Test
+    void noRangeWithCap_appliesDefaultLimit() {
+        var resolved = PostgrestRowLimitResolver.resolve(null, 1000);
+        assertThat(resolved.offset()).isEqualTo(0L);
+        assertThat(resolved.limit()).isEqualTo(1000L);
+    }
+
+    @Test
+    void noRangeWithoutCap_leavesUnbounded() {
+        var resolved = PostgrestRowLimitResolver.resolve(null, null);
+        assertThat(resolved.offset()).isNull();
+        assertThat(resolved.limit()).isNull();
+    }
+
+    @Test
+    void clientRangeWithinCap_keepsRequestedLimit() {
+        var range = RangeHeader.builder().unit("items").start(0L).end(9L).build();
+        var resolved = PostgrestRowLimitResolver.resolve(range, 1000);
+        assertThat(resolved.offset()).isEqualTo(0L);
+        assertThat(resolved.limit()).isEqualTo(10L);
+    }
+
+    @Test
+    void clientRangeAboveCap_truncatesToCap() {
+        var range = RangeHeader.builder().unit("items").start(0L).end(4999L).build();
+        var resolved = PostgrestRowLimitResolver.resolve(range, 1000);
+        assertThat(resolved.offset()).isEqualTo(0L);
+        assertThat(resolved.limit()).isEqualTo(1000L);
+    }
+
+    @Test
+    void openEndedRangeWithCap_limitsToCapFromOffset() {
+        var range = RangeHeader.builder().unit("items").start(10L).end(null).build();
+        var resolved = PostgrestRowLimitResolver.resolve(range, 1000);
+        assertThat(resolved.offset()).isEqualTo(10L);
+        assertThat(resolved.limit()).isEqualTo(1000L);
+    }
+
+    @Test
+    void legacyRangeWithoutCap_preservesExistingPlannerSemantics() {
+        var range = RangeHeader.builder().unit("items").start(0L).end(9L).build();
+        var resolved = PostgrestRowLimitResolver.resolve(range, null);
+        assertThat(resolved.offset()).isEqualTo(0L);
+        assertThat(resolved.limit()).isEqualTo(10L);
+    }
+}

--- a/src/test/java/ai/nubase/postgrest/query/QueryPlannerTest.java
+++ b/src/test/java/ai/nubase/postgrest/query/QueryPlannerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import ai.nubase.postgrest.multidb.DatabaseConfig;
 import ai.nubase.postgrest.multidb.SchemaCacheManager;
 import ai.nubase.postgrest.schema.ForeignKey;
 import ai.nubase.postgrest.schema.SchemaCache;
@@ -211,6 +212,55 @@ class QueryPlannerTest {
         // Verify
         assertEquals(0L, plan.getOffset());
         assertEquals(10L, plan.getLimit());
+    }
+
+    @Test
+    void selectWithoutRange_appliesDbMaxRowsFromTenantConfig() {
+        MultiTenancyContext.setContext(MultiTenancyContext.ContextData.builder()
+                .appCode("test_app")
+                .databaseKey("test_db")
+                .schemaName("public")
+                .databaseConfig(DatabaseConfig.builder().dbMaxRows(1000).build())
+                .build());
+
+        ApiRequest request = ApiRequest.builder()
+                .schema("public")
+                .table("users")
+                .method("GET")
+                .build();
+
+        when(schemaCache.getTable(anyString(), anyString())).thenReturn(
+                Table.builder().columns(new ArrayList<>()).build());
+
+        QueryPlan plan = queryPlanner.plan(request);
+
+        assertEquals(0L, plan.getOffset());
+        assertEquals(1000L, plan.getLimit());
+    }
+
+    @Test
+    void selectWithOversizedRange_capsLimitToDbMaxRows() {
+        MultiTenancyContext.setContext(MultiTenancyContext.ContextData.builder()
+                .appCode("test_app")
+                .databaseKey("test_db")
+                .schemaName("public")
+                .databaseConfig(DatabaseConfig.builder().dbMaxRows(100).build())
+                .build());
+
+        ApiRequest request = ApiRequest.builder()
+                .schema("public")
+                .table("users")
+                .method("GET")
+                .range(RangeHeader.builder().unit("items").start(0L).end(999L).build())
+                .build();
+
+        when(schemaCache.getTable(anyString(), anyString())).thenReturn(
+                Table.builder().columns(new ArrayList<>()).build());
+
+        QueryPlan plan = queryPlanner.plan(request);
+
+        assertEquals(0L, plan.getOffset());
+        assertEquals(100L, plan.getLimit());
     }
 
     @Test


### PR DESCRIPTION
## 论证：这是缺陷，有必要修

1. **配置链路完整，执行链路断裂** — `database_configs.db_max_rows` 有表字段、新项目默认 `1000`、`PostgRESTConfig` 注释为 *Maximum number of rows returned*，但 `QueryPlanner` 从未读取。
2. **与 PostgREST 语义不符** — 官方 `db-max-rows` 对 GET 无 Range 时施加默认上限，并对客户端过大的 Range 封顶；当前无 Range 时可能无界 `SELECT`。
3. **有实际风险** — 大表 REST 查询可拖垮租户 DB / 应用内存；初始化写死 1000 说明作者预期存在上限。
4. **不是刻意禁用** — 无 feature flag、无「暂未实现」注释；`Preferences.maxRows` 字段存在但未接线，属于半成品。

本 PR **有意不做**：`Prefer: max-rows`、`count=estimated` 阈值、mutation 路径（PostgREST 亦不对 POST/PATCH/DELETE 套 `db-max-rows`）。

## Summary
- 新增 `PostgrestRowLimitResolver`，合并 `db_max_rows` 与 Range/limit
- `QueryPlanner` 的 GET / RPC 读路径通过 `MultiTenancyContext.getDatabaseConfig()` 应用上限
- `db_max_rows` 为 null 或 ≤0 时不施加默认 LIMIT（尊重可空列）

## Test plan
- [x] `mvn test -Dtest=PostgrestRowLimitResolverTest,QueryPlannerTest`