### PR TITLE
fix(auth): require verified email before OAuth account merge

### DIFF
--- a/src/main/java/ai/nubase/auth/oauth/GitHubOAuthProvider.java
+++ b/src/main/java/ai/nubase/auth/oauth/GitHubOAuthProvider.java
@@ -109,7 +109,7 @@ public class GitHubOAuthProvider implements OAuthProvider {
 
         JsonNode userInfo = objectMapper.readTree(userResponse.getBody());
 
-        // Get user emails (GitHub may not include email in basic info)
+        // 与 PlatformOAuthService 一致：只采用 GitHub /user/emails 中 verified 的地址，不信任公开 profile email。
         String email = null;
         boolean emailVerified = false;
         try {
@@ -122,26 +122,28 @@ public class GitHubOAuthProvider implements OAuthProvider {
 
             JsonNode emails = objectMapper.readTree(emailResponse.getBody());
             if (emails.isArray()) {
+                String firstVerified = null;
                 for (JsonNode emailNode : emails) {
+                    if (!emailNode.has("verified") || !emailNode.get("verified").asBoolean()) {
+                        continue;
+                    }
+                    String candidate = emailNode.get("email").asText();
                     if (emailNode.has("primary") && emailNode.get("primary").asBoolean()) {
-                        email = emailNode.get("email").asText();
-                        emailVerified = emailNode.has("verified") && emailNode.get("verified").asBoolean();
+                        email = candidate;
+                        emailVerified = true;
                         break;
                     }
+                    if (firstVerified == null) {
+                        firstVerified = candidate;
+                    }
                 }
-                // If no primary email, use the first one
-                if (email == null && emails.size() > 0) {
-                    email = emails.get(0).get("email").asText();
-                    emailVerified = emails.get(0).has("verified") && emails.get(0).get("verified").asBoolean();
+                if (email == null && firstVerified != null) {
+                    email = firstVerified;
+                    emailVerified = true;
                 }
             }
         } catch (Exception e) {
             log.warn("Failed to fetch GitHub user emails: {}", e.getMessage());
-        }
-
-        // If still no email, try to get from basic user info
-        if (email == null && userInfo.has("email") && !userInfo.get("email").isNull()) {
-            email = userInfo.get("email").asText();
         }
 
         return OAuthUserInfo.builder()

--- a/src/main/java/ai/nubase/auth/service/OAuthService.java
+++ b/src/main/java/ai/nubase/auth/service/OAuthService.java
@@ -47,6 +47,7 @@ public class OAuthService {
     private final TokenService tokenService;
     private final UserMapper userMapper;
     private final AuthConfig authConfig;
+    private final EffectiveAuthConfig effectiveAuthConfig;
     private final AuthResponseFactory authResponseFactory;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -192,8 +193,17 @@ public class OAuthService {
         }
 
         if (existingUser.isPresent()) {
-            log.debug("Found existing user with email: {}", oauthUserInfo.getEmail());
+            // 与新建用户路径一致：仅 IdP 已验证邮箱才允许按 email 自动合并，避免未验证邮箱绑到他人账号。
+            // 租户开启邮箱确认时，还要求目标账号已完成确认，防止 OAuth 绕过密码注册的确认流程。
+            if (!oauthUserInfo.isEmailVerified()) {
+                throw new RuntimeException(
+                        "OAuth email is not verified by the provider; cannot link to an existing account");
+            }
             User user = existingUser.get();
+            if (effectiveAuthConfig.emailConfirmationRequired() && user.getEmailConfirmedAt() == null) {
+                throw new RuntimeException("Existing account email is not confirmed");
+            }
+            log.debug("Linking OAuth identity to confirmed user by verified email: {}", oauthUserInfo.getEmail());
             mergeProviderMetadata(user, oauthUserInfo.getProvider());
             return userRepository.save(user);
         }

--- a/src/test/java/ai/nubase/auth/service/OAuthServiceEmailLinkTest.java
+++ b/src/test/java/ai/nubase/auth/service/OAuthServiceEmailLinkTest.java
@@ -1,0 +1,123 @@
+package ai.nubase.auth.service;
+
+import ai.nubase.auth.dto.oauth.OAuthUserInfo;
+import ai.nubase.auth.entity.User;
+import ai.nubase.auth.oauth.OAuthProvider;
+import ai.nubase.auth.repository.IdentityRepository;
+import ai.nubase.auth.repository.SessionRepository;
+import ai.nubase.auth.repository.UserRepository;
+import ai.nubase.auth.util.UserMapper;
+import ai.nubase.common.config.AuthConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("OAuthService email auto-link guards")
+class OAuthServiceEmailLinkTest {
+
+    private UserRepository userRepository;
+    private IdentityRepository identityRepository;
+    private EffectiveAuthConfig effectiveAuthConfig;
+    private OAuthService svc;
+
+    private final UUID victimId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        identityRepository = mock(IdentityRepository.class);
+        effectiveAuthConfig = mock(EffectiveAuthConfig.class);
+        OAuthProvider provider = mock(OAuthProvider.class);
+
+        svc = new OAuthService(
+                Map.of("github", provider),
+                userRepository,
+                identityRepository,
+                mock(SessionRepository.class),
+                mock(JwtSecretService.class),
+                mock(TokenService.class),
+                new UserMapper(),
+                new AuthConfig(),
+                effectiveAuthConfig,
+                mock(AuthResponseFactory.class));
+
+        when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(identityRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(identityRepository.findByProviderAndProviderId(any(), any())).thenReturn(Optional.empty());
+        when(effectiveAuthConfig.emailConfirmationRequired()).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("rejects auto-link when OAuth email is not provider-verified")
+    void rejectsUnverifiedProviderEmail() {
+        User victim = confirmedUser("victim@x.com");
+        when(userRepository.findByEmail("victim@x.com")).thenReturn(Optional.of(victim));
+
+        OAuthUserInfo info = OAuthUserInfo.builder()
+                .provider("github").providerId("gh-1")
+                .email("victim@x.com").emailVerified(false).build();
+
+        assertThatThrownBy(() -> svc.signInWithProviderInfo(info, false))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("not verified by the provider");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("rejects auto-link when existing account email is not confirmed")
+    void rejectsUnconfirmedTenantEmail() {
+        User victim = User.builder()
+                .id(victimId)
+                .email("victim@x.com")
+                .emailConfirmedAt(null)
+                .build();
+        when(userRepository.findByEmail("victim@x.com")).thenReturn(Optional.of(victim));
+
+        OAuthUserInfo info = OAuthUserInfo.builder()
+                .provider("github").providerId("gh-1")
+                .email("victim@x.com").emailVerified(true).build();
+
+        assertThatThrownBy(() -> svc.signInWithProviderInfo(info, false))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("not confirmed");
+    }
+
+    @Test
+    @DisplayName("allows auto-link when provider email is verified and tenant email is confirmed")
+    void allowsVerifiedLink() {
+        User victim = confirmedUser("victim@x.com");
+        when(userRepository.findByEmail("victim@x.com")).thenReturn(Optional.of(victim));
+
+        OAuthUserInfo info = OAuthUserInfo.builder()
+                .provider("github").providerId("gh-1")
+                .email("victim@x.com").emailVerified(true).build();
+
+        OAuthService.ProviderSignIn result = svc.signInWithProviderInfo(info, false);
+
+        assertThat(result.user().getId()).isEqualTo(victimId);
+        verify(userRepository, org.mockito.Mockito.atLeastOnce()).save(victim);
+        verify(identityRepository, org.mockito.Mockito.atLeastOnce()).save(any());
+    }
+
+    private User confirmedUser(String email) {
+        return User.builder()
+                .id(victimId)
+                .email(email)
+                .emailConfirmedAt(Instant.now())
+                .build();
+    }
+}

--- a/src/test/java/ai/nubase/auth/service/OAuthServiceTest.java
+++ b/src/test/java/ai/nubase/auth/service/OAuthServiceTest.java
@@ -32,6 +32,7 @@ class OAuthServiceTest {
     private UserRepository userRepository;
     private IdentityRepository identityRepository;
     private AuthResponseFactory authResponseFactory;
+    private EffectiveAuthConfig effectiveAuthConfig;
     private OAuthProvider provider;
     private OAuthService svc;
 
@@ -43,6 +44,7 @@ class OAuthServiceTest {
         userRepository = mock(UserRepository.class);
         identityRepository = mock(IdentityRepository.class);
         authResponseFactory = mock(AuthResponseFactory.class);
+        effectiveAuthConfig = mock(EffectiveAuthConfig.class);
         provider = mock(OAuthProvider.class);
         when(provider.getProviderName()).thenReturn("google");
         when(provider.getUserInfo("code", "uri")).thenReturn(OAuthUserInfo.builder()
@@ -52,7 +54,7 @@ class OAuthServiceTest {
                 Map.of("google", provider), userRepository, identityRepository,
                 mock(ai.nubase.auth.repository.SessionRepository.class), mock(JwtSecretService.class),
                 mock(TokenService.class), new ai.nubase.auth.util.UserMapper(), new AuthConfig(),
-                authResponseFactory);
+                effectiveAuthConfig, authResponseFactory);
 
         when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(identityRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));


### PR DESCRIPTION
## Summary
- Reject OAuth auto-link by email when the IdP has not verified the address, closing a path where an unverified GitHub email could bind to another user's account.
- When tenant email confirmation is enabled, also require the existing account to be confirmed before merging, matching the checks applied on new-user creation.
- Align tenant `GitHubOAuthProvider` with platform login: select only verified emails from `/user/emails` (primary verified first), with no fallback to unverified profile email.

## Test plan
- [x] `mvn test -Dtest=OAuthServiceEmailLinkTest,OAuthServiceTest`
- [ ] Manual: GitHub OAuth with unverified email must not link to an existing account
- [ ] Manual: verified GitHub email + confirmed tenant account links successfully