### PR TITLE
feat(deploy): app worker backend management with MCP + skill

### DIFF
--- a/frontend/packages/mcp-bridge/skills/nubase/SKILL.md
+++ b/frontend/packages/mcp-bridge/skills/nubase/SKILL.md
@@ -58,11 +58,11 @@ Core:
 
 Backend ops (read), in module order (Database, Auth, Storage, AI Gateway): `db_export_schema`, `db_list_migrations`, `auth_list_users`, `auth_get_settings`, `storage_list_buckets`, `storage_list_objects`, `storage_create_signed_url`, `storage_create_signed_urls`, `gateway_list_keys`, `gateway_usage`, `gateway_usage_daily`, `gateway_usage_by_model`, `gateway_usage_logs`, `gateway_pricing`.
 
-Deploy (read), in module order (Assets, Functions, cron): `assets_list`, `functions_list`, `functions_logs`, `functions_secrets_list`, `cron_list`, `cron_get`, `cron_runs`.
+Deploy (read), in module order (Assets, Functions, cron, App workers): `assets_list`, `functions_list`, `functions_logs`, `functions_secrets_list`, `cron_list`, `cron_get`, `cron_runs`, `app_workers_list`, `app_worker_status`.
 
 Backend ops (write, gated by `NUBASE_ALLOW_ADMIN_WRITE=true`): `auth_create_user`, `auth_delete_user`, `auth_update_settings`, `auth_clear_settings`, `storage_create_bucket`, `storage_delete_bucket`, `storage_create_signed_upload_url`, `gateway_issue_key`, `gateway_revoke_key`.
 
-Deploy (write, gated by `NUBASE_ALLOW_ADMIN_WRITE=true`): `deploy_app`, `deployment_rollback`, `assets_upload`, `assets_delete`, `assets_update_settings`, `functions_new`, `functions_deploy`, `functions_invoke`, `functions_delete`, `functions_secrets_set`, `cron_create`, `cron_update`, `cron_delete`.
+Deploy (write, gated by `NUBASE_ALLOW_ADMIN_WRITE=true`): `deploy_app`, `deployment_rollback`, `assets_upload`, `assets_delete`, `assets_update_settings`, `functions_new`, `functions_deploy`, `functions_invoke`, `functions_delete`, `functions_secrets_set`, `cron_create`, `cron_update`, `cron_delete`, `app_worker_delete`.
 
 Project lifecycle (platform auth required with `NUBASE_PLATFORM_JWT` or `NUBASE_PLATFORM_KEY`): `projects_list`, `project_keys_admin`, `project_select_instructions`. `project_provision` and `project_update` are also gated by `NUBASE_ALLOW_ADMIN_WRITE=true`. Project delete is intentionally not exposed.
 
@@ -142,4 +142,5 @@ Use these focused references when the task is clearly scoped:
 - `references/ai-gateway.md`
 - `references/memory.md`
 - `references/cron.md` — schedule recurring jobs
+- `references/app-workers.md` — deploy & manage full app workers (server + bundled assets)
 - `references/security.md`

--- a/frontend/packages/mcp-bridge/skills/nubase/references/app-workers.md
+++ b/frontend/packages/mcp-bridge/skills/nubase/references/app-workers.md
@@ -1,0 +1,70 @@
+# Nubase App Workers Reference
+
+Use this reference when shipping or managing a **full app worker** — a generated app deployed as a single Cloudflare Worker (server module + bundled static assets) onto Nubase's Workers-for-Platforms dispatch namespace, reachable at its own preview host.
+
+App workers are the **server-rendered / full-stack** deploy target. Unlike `assets_*` (static frontend only) or `functions_*` (individual edge handlers), one app worker bundles a server entry module **and** its client `dist/` into a single isolated deployment per project.
+
+## When to use which deploy target
+
+- Static frontend only (HTML/CSS/JS) → **Assets** (`assets_*`, `references/assets.md`).
+- A few backend handlers → **Functions** (`functions_*`, `references/functions.md`).
+- A whole app shipped as one server worker (SSR / API + bundled client) → **App worker** (this doc).
+
+## Deploy
+
+Deploying an app worker uploads a server bundle plus optional client assets. Because it is a multipart file upload, it runs through the CLI / deploy pipeline rather than a single MCP argument:
+
+```http
+POST /deployments/admin/v1/app-workers/deploy   (multipart/form-data, service_role)
+  metadata   = JSON  { appCode, version, workerName?, mainModule, serverEntrypointPath?,
+                       clientDistPath?, previewHost?, compatibilityDate?, compatibilityFlags?,
+                       envBindings?, plainTextBindings?, secretTextBindings? }
+  serverFile = one or more JS module files (must include mainModule)
+  assetFile  = zero or more static asset files (served via the worker's ASSETS binding)
+```
+
+- `workerName` defaults to `appCode`; `previewHost` defaults to `<workerName>.ottermind.app`.
+- `metadata.appCode` must match the calling project context (enforced server-side).
+- A custom `workerName` must equal `appCode` or be namespaced under it (`<appCode>-<suffix>`, e.g. `appabc-preview`). The dispatch namespace is shared across tenants, so a worker name outside your appCode is rejected with 403.
+- `NUBASE_PROJECT_REF` and `NUBASE_APP_VERSION` are injected as bindings automatically and cannot be overridden; pass app config via `plainTextBindings` and secrets via `secretTextBindings`.
+- The deploy is recorded in the project's deployment history (`deployments_list` / `deployment_status`).
+
+## Manage (after deploy)
+
+Management is **scoped to workers this project has deployed** — the dispatch namespace is shared across all tenants, so list/status/delete only ever resolve workers found in *this* project's deployment history. You cannot read or delete another project's worker.
+
+Read (always available):
+
+- `app_workers_list()` — list this project's deployed app workers, each with `workerName`, latest `version`, `previewHost`, `publicUrl`, `lastDeploymentStatus`, `lastDeploymentId`, and timestamps.
+- `app_worker_status({ workerName })` — one worker enriched with **live provider state**: returns `{ worker, existsOnProvider, provider }`, where `existsOnProvider:false` means the worker is no longer present on Cloudflare (e.g. deleted out-of-band).
+
+Write (gated by `NUBASE_ALLOW_ADMIN_WRITE=true` and the project's service_role key; otherwise returns `{ success: false, ... }` without touching the backend):
+
+- `app_worker_delete({ workerName })` — undeploy one app worker. Idempotent (deleting an already-absent worker still succeeds) and records an `app_worker_delete` entry in deployment history for audit. Returns `{ workerName, deleted, auditDeploymentId }`.
+
+Equivalent control-plane HTTP endpoints (service_role):
+
+```http
+GET    /deployments/admin/v1/app-workers
+GET    /deployments/admin/v1/app-workers/{workerName}
+DELETE /deployments/admin/v1/app-workers/{workerName}
+```
+
+## Worked Example: inspect then retire a worker
+
+```text
+app_workers_list()
+# → [{ workerName: "my-app", version: "2", publicUrl: "https://my-app.ottermind.app", lastDeploymentStatus: "succeeded", ... }]
+
+app_worker_status({ "workerName": "my-app" })
+# → { worker: {...}, existsOnProvider: true, provider: { ...live Cloudflare script details... } }
+
+app_worker_delete({ "workerName": "my-app" })   # needs NUBASE_ALLOW_ADMIN_WRITE=true + service_role
+# → { workerName: "my-app", deleted: true, auditDeploymentId: "..." }
+```
+
+## Safety
+
+- Deleting an app worker takes the live app offline immediately — ask the user before calling `app_worker_delete`, the same as any destructive deploy op.
+- Never put service_role keys or other secrets in `plainTextBindings` (those are plain text) or in bundled `assetFile` contents (assets are public). Use `secretTextBindings` for secrets.
+- After deploying or retiring an app worker, `memory_write` the durable facts (worker name, preview host, version).

--- a/frontend/packages/mcp-bridge/src/nubase-client.ts
+++ b/frontend/packages/mcp-bridge/src/nubase-client.ts
@@ -585,6 +585,24 @@ export class NubaseClient {
     );
   }
 
+  // --- App workers control plane (/deployments/admin/v1/app-workers) -------
+
+  appWorkersList() {
+    return this.request('/deployments/admin/v1/app-workers');
+  }
+
+  appWorkerStatus(args: Record<string, unknown>) {
+    const workerName = requiredString(args.workerName, 'workerName');
+    return this.request(`/deployments/admin/v1/app-workers/${encodeURIComponent(workerName)}`);
+  }
+
+  appWorkerDelete(args: Record<string, unknown>) {
+    const workerName = requiredString(args.workerName, 'workerName');
+    return this.guardedWrite('delete app worker', () =>
+      this.request(`/deployments/admin/v1/app-workers/${encodeURIComponent(workerName)}`, { method: 'DELETE' })
+    );
+  }
+
   // --- Project lifecycle control plane (/auth/v1/admin/projects) ----------
 
   projectsList() {

--- a/frontend/packages/mcp-bridge/src/tools.ts
+++ b/frontend/packages/mcp-bridge/src/tools.ts
@@ -135,6 +135,25 @@ const TOOL_TABLE: Record<string, ToolEntry> = {
     }, ['id']),
     handler: (args, _config, client) => client.deploymentRollback(args),
   },
+  app_workers_list: {
+    description: 'List the app workers (Cloudflare Workers) this project has deployed, with their latest version, preview URL and status. Scoped to the current project. Read-only.',
+    inputSchema: objectSchema({}),
+    handler: (_args, _config, client) => client.appWorkersList(),
+  },
+  app_worker_status: {
+    description: 'Get one deployed app worker for this project, enriched with live provider state. Read-only.',
+    inputSchema: objectSchema({
+      workerName: { type: 'string' },
+    }, ['workerName']),
+    handler: (args, _config, client) => client.appWorkerStatus(args),
+  },
+  app_worker_delete: {
+    description: 'Delete (undeploy) one app worker owned by this project. Write op; disabled unless NUBASE_ALLOW_ADMIN_WRITE=true. Only affects workers this project has deployed.',
+    inputSchema: objectSchema({
+      workerName: { type: 'string' },
+    }, ['workerName']),
+    handler: (args, _config, client) => client.appWorkerDelete(args),
+  },
   memory_context: {
     description: 'Return compact relevant memory context for a task. Scope defaults can come from NUBASE_USER_ID, NUBASE_AGENT_ID, and NUBASE_RUN_ID.',
     inputSchema: objectSchema({

--- a/frontend/packages/mcp-bridge/test/deploy-app.test.ts
+++ b/frontend/packages/mcp-bridge/test/deploy-app.test.ts
@@ -25,6 +25,9 @@ test('MCP tool list includes deploy_app', () => {
   assert.equal(names.has('deployment_status'), true);
   assert.equal(names.has('deployment_logs'), true);
   assert.equal(names.has('deployment_rollback'), true);
+  assert.equal(names.has('app_workers_list'), true);
+  assert.equal(names.has('app_worker_status'), true);
+  assert.equal(names.has('app_worker_delete'), true);
   assert.equal(names.has('projects_list'), true);
   assert.equal(names.has('project_keys_admin'), true);
   assert.equal(names.has('project_provision'), true);
@@ -41,6 +44,36 @@ test('MCP tool list includes deploy_app', () => {
   assert.equal(names.has('gateway_usage_by_model'), true);
   assert.equal(names.has('gateway_usage_logs'), true);
   assert.equal(names.has('gateway_pricing'), true);
+});
+
+test('app worker tools dispatch to the matching client method', async () => {
+  const calls: Array<{ op: string; args?: Record<string, unknown> }> = [];
+  const client = {
+    appWorkersList: async () => {
+      calls.push({ op: 'appWorkersList' });
+      return [{ workerName: 'my-app' }];
+    },
+    appWorkerStatus: async (args: Record<string, unknown>) => {
+      calls.push({ op: 'appWorkerStatus', args });
+      return { worker: { workerName: args.workerName }, existsOnProvider: true };
+    },
+    appWorkerDelete: async (args: Record<string, unknown>) => {
+      calls.push({ op: 'appWorkerDelete', args });
+      return { workerName: args.workerName, deleted: true };
+    },
+  } as unknown as Parameters<typeof callTool>[3];
+
+  const listed = await callTool('app_workers_list', {}, config(), client) as Array<Record<string, unknown>>;
+  assert.equal(listed[0]?.workerName, 'my-app');
+
+  const status = await callTool('app_worker_status', { workerName: 'my-app' }, config(), client) as Record<string, any>;
+  assert.equal(status.existsOnProvider, true);
+
+  const deleted = await callTool('app_worker_delete', { workerName: 'my-app' }, config(), client) as Record<string, any>;
+  assert.equal(deleted.deleted, true);
+
+  assert.deepEqual(calls.map((call) => call.op), ['appWorkersList', 'appWorkerStatus', 'appWorkerDelete']);
+  assert.equal(calls[1]?.args?.workerName, 'my-app');
 });
 
 test('deploy_app orchestrates migrations, functions, assets, cron, and memory', async () => {

--- a/src/main/java/ai/nubase/deploy/controller/AppDeploymentAdminController.java
+++ b/src/main/java/ai/nubase/deploy/controller/AppDeploymentAdminController.java
@@ -2,8 +2,11 @@ package ai.nubase.deploy.controller;
 
 import ai.nubase.auth.annotation.RequireServiceRole;
 import ai.nubase.deploy.dto.AppDeploymentDtos.CompleteDeploymentRequest;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerDeleteResponse;
 import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerDeployMetadata;
 import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerDeployResponse;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerDetail;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerSummary;
 import ai.nubase.deploy.dto.AppDeploymentDtos.CreateDeploymentRequest;
 import ai.nubase.deploy.dto.AppDeploymentDtos.DeploymentDetailResponse;
 import ai.nubase.deploy.dto.AppDeploymentDtos.DeploymentResponse;
@@ -13,9 +16,11 @@ import ai.nubase.deploy.dto.AppDeploymentDtos.RollbackDeploymentResponse;
 import ai.nubase.deploy.service.AppDeploymentRollbackService;
 import ai.nubase.deploy.service.AppDeploymentService;
 import ai.nubase.deploy.service.AppWorkerDeployService;
+import ai.nubase.deploy.service.AppWorkerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,6 +45,7 @@ public class AppDeploymentAdminController {
     private final AppDeploymentService deploymentService;
     private final AppDeploymentRollbackService rollbackService;
     private final AppWorkerDeployService appWorkerDeployService;
+    private final AppWorkerService appWorkerService;
     private final ObjectMapper objectMapper;
 
     @PostMapping("/deployments")
@@ -81,6 +87,21 @@ public class AppDeploymentAdminController {
     @PostMapping("/deployments/{id}/rollback")
     public ResponseEntity<RollbackDeploymentResponse> rollback(@PathVariable UUID id) {
         return ResponseEntity.ok(rollbackService.rollback(id));
+    }
+
+    @GetMapping("/app-workers")
+    public ResponseEntity<List<AppWorkerSummary>> listAppWorkers() {
+        return ResponseEntity.ok(appWorkerService.list());
+    }
+
+    @GetMapping("/app-workers/{workerName}")
+    public ResponseEntity<AppWorkerDetail> getAppWorker(@PathVariable String workerName) {
+        return ResponseEntity.ok(appWorkerService.get(workerName));
+    }
+
+    @DeleteMapping("/app-workers/{workerName}")
+    public ResponseEntity<AppWorkerDeleteResponse> deleteAppWorker(@PathVariable String workerName) {
+        return ResponseEntity.ok(appWorkerService.delete(workerName));
     }
 
     @PostMapping(value = "/app-workers/deploy", consumes = "multipart/form-data")

--- a/src/main/java/ai/nubase/deploy/dto/AppDeploymentDtos.java
+++ b/src/main/java/ai/nubase/deploy/dto/AppDeploymentDtos.java
@@ -147,4 +147,33 @@ public final class AppDeploymentDtos {
             String errorMessage
     ) {
     }
+
+    /** One app worker the current project owns, derived from its deployment history. */
+    public record AppWorkerSummary(
+            String workerName,
+            String projectRef,
+            String version,
+            String previewHost,
+            String publicUrl,
+            String lastDeploymentStatus,
+            UUID lastDeploymentId,
+            Instant deployedAt,
+            Instant completedAt
+    ) {
+    }
+
+    /** An app worker summary enriched with live provider state. */
+    public record AppWorkerDetail(
+            AppWorkerSummary worker,
+            boolean existsOnProvider,
+            Object provider
+    ) {
+    }
+
+    public record AppWorkerDeleteResponse(
+            String workerName,
+            boolean deleted,
+            UUID auditDeploymentId
+    ) {
+    }
 }

--- a/src/main/java/ai/nubase/deploy/service/AppWorkerDeployService.java
+++ b/src/main/java/ai/nubase/deploy/service/AppWorkerDeployService.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 @Service
@@ -147,8 +148,26 @@ public class AppWorkerDeployService {
         if (StringUtils.hasText(contextApp) && !contextApp.equals(metadata.appCode())) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "metadata.appCode must match project context");
         }
+        requireWorkerNameOwnedByApp(metadata.appCode(), metadata.workerName());
         if (serverFiles == null || serverFiles.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "serverFile is required");
+        }
+    }
+
+    /**
+     * The Cloudflare dispatch namespace is shared across tenants, so a custom workerName is only
+     * allowed when it is namespaced under the project's appCode. This prevents one project from
+     * deploying over another project's worker. When omitted, workerName defaults to appCode.
+     */
+    private void requireWorkerNameOwnedByApp(String appCode, String workerName) {
+        if (!StringUtils.hasText(workerName)) {
+            return;
+        }
+        String app = appCode.trim().toLowerCase(Locale.ROOT);
+        String worker = workerName.trim().toLowerCase(Locale.ROOT);
+        if (!worker.equals(app) && !worker.startsWith(app + "-")) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "metadata.workerName must equal the project appCode or start with \"" + app + "-\"");
         }
     }
 

--- a/src/main/java/ai/nubase/deploy/service/AppWorkerDeployer.java
+++ b/src/main/java/ai/nubase/deploy/service/AppWorkerDeployer.java
@@ -1,5 +1,18 @@
 package ai.nubase.deploy.service;
 
 public interface AppWorkerDeployer {
+
     AppWorkerDeploymentResult deploy(AppWorkerDeploymentRequest request);
+
+    /**
+     * Read live provider state for one worker. Returns {@link AppWorkerInfo#exists()} == false
+     * when the worker is not present (already deleted / never deployed).
+     */
+    AppWorkerInfo get(String workerName);
+
+    /**
+     * Remove (undeploy) one worker from the provider. Idempotent: deleting an absent worker
+     * is treated as success.
+     */
+    void delete(String workerName);
 }

--- a/src/main/java/ai/nubase/deploy/service/AppWorkerInfo.java
+++ b/src/main/java/ai/nubase/deploy/service/AppWorkerInfo.java
@@ -1,0 +1,14 @@
+package ai.nubase.deploy.service;
+
+import java.util.Map;
+
+/**
+ * Live state of a deployed app worker as reported by the deploy provider
+ * (e.g. a Cloudflare Workers for Platforms dispatch-namespace script).
+ */
+public record AppWorkerInfo(
+        String workerName,
+        boolean exists,
+        Map<String, Object> details
+) {
+}

--- a/src/main/java/ai/nubase/deploy/service/AppWorkerService.java
+++ b/src/main/java/ai/nubase/deploy/service/AppWorkerService.java
@@ -1,0 +1,166 @@
+package ai.nubase.deploy.service;
+
+import ai.nubase.common.context.MultiTenancyContext;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerDeleteResponse;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerDetail;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerSummary;
+import ai.nubase.deploy.dto.AppDeploymentDtos.CompleteDeploymentRequest;
+import ai.nubase.deploy.dto.AppDeploymentDtos.CreateDeploymentRequest;
+import ai.nubase.deploy.dto.AppDeploymentDtos.DeploymentResponse;
+import ai.nubase.deploy.dto.AppDeploymentDtos.RecordDeploymentStepRequest;
+import ai.nubase.metadata.entity.AppDeployment;
+import ai.nubase.metadata.entity.AppDeploymentStep;
+import ai.nubase.metadata.repository.AppDeploymentRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Control-plane management for deployed app workers. The Cloudflare dispatch namespace is shared
+ * across all tenants, so every operation is scoped to workers the current project actually owns —
+ * ownership is derived from this project's own {@code app_deployments} history, never from the
+ * shared namespace listing.
+ */
+@Service
+@RequiredArgsConstructor
+public class AppWorkerService {
+
+    private static final int SCAN_LIMIT = 200;
+    private static final String TYPE_APP_WORKER = "app_worker";
+
+    private final AppDeploymentRepository deploymentRepository;
+    private final AppDeploymentService deploymentService;
+    private final AppWorkerDeployer deployer;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
+    public List<AppWorkerSummary> list() {
+        return ownedWorkers().values().stream()
+                .map(this::toSummary)
+                .sorted(Comparator.comparing(AppWorkerSummary::workerName))
+                .toList();
+    }
+
+    @Transactional(transactionManager = "metadataTransactionManager", readOnly = true)
+    public AppWorkerDetail get(String workerName) {
+        OwnedWorker owned = requireOwned(workerName);
+        AppWorkerInfo info = deployer.get(owned.workerName());
+        return new AppWorkerDetail(toSummary(owned), info.exists(), info.details());
+    }
+
+    @Transactional("metadataTransactionManager")
+    public AppWorkerDeleteResponse delete(String workerName) {
+        OwnedWorker owned = requireOwned(workerName);
+        deployer.delete(owned.workerName());
+        DeploymentResponse audit = recordDeletion(owned);
+        return new AppWorkerDeleteResponse(owned.workerName(), true, audit.id());
+    }
+
+    private OwnedWorker requireOwned(String workerName) {
+        if (!StringUtils.hasText(workerName)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "workerName is required");
+        }
+        OwnedWorker owned = ownedWorkers().get(canonical(workerName));
+        if (owned == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "App worker not found for this project: " + workerName.trim());
+        }
+        return owned;
+    }
+
+    /** Latest app-worker deployment per worker name owned by the current project, keyed by canonical name. */
+    private Map<String, OwnedWorker> ownedWorkers() {
+        String projectRef = projectRef();
+        List<AppDeployment> deployments = deploymentRepository
+                .findByProjectRefOrderByCreatedAtDesc(projectRef, PageRequest.of(0, SCAN_LIMIT));
+        Map<String, OwnedWorker> byName = new LinkedHashMap<>();
+        for (AppDeployment deployment : deployments) {
+            Map<String, Object> summary = readSummary(deployment.getManifestSummary());
+            if (!TYPE_APP_WORKER.equals(summary.get("type"))) continue;
+            String workerName = str(summary.get("workerName"));
+            if (workerName == null) workerName = str(summary.get("appCode"));
+            if (workerName == null) continue;
+            // Deployments arrive newest-first; keep the most recent record per worker.
+            byName.putIfAbsent(canonical(workerName), new OwnedWorker(canonical(workerName), deployment, summary));
+        }
+        return byName;
+    }
+
+    private DeploymentResponse recordDeletion(OwnedWorker owned) {
+        DeploymentResponse record = deploymentService.create(new CreateDeploymentRequest(
+                str(owned.summary().get("appCode")),
+                Map.of("type", "app_worker_delete", "workerName", owned.workerName()),
+                null,
+                null
+        ));
+        deploymentService.recordStep(record.id(), new RecordDeploymentStepRequest(
+                1,
+                "cloudflare_app_worker_delete",
+                owned.workerName(),
+                AppDeploymentStep.STATUS_SUCCEEDED,
+                Map.of("workerName", owned.workerName()),
+                null
+        ));
+        return deploymentService.complete(record.id(), new CompleteDeploymentRequest(
+                AppDeployment.STATUS_SUCCEEDED,
+                null,
+                null
+        ));
+    }
+
+    private AppWorkerSummary toSummary(OwnedWorker owned) {
+        AppDeployment deployment = owned.deployment();
+        Map<String, Object> summary = owned.summary();
+        return new AppWorkerSummary(
+                owned.workerName(),
+                deployment.getProjectRef(),
+                str(summary.get("version")),
+                str(summary.get("previewHost")),
+                deployment.getPublicUrl(),
+                deployment.getStatus(),
+                deployment.getId(),
+                deployment.getCreatedAt(),
+                deployment.getCompletedAt()
+        );
+    }
+
+    private Map<String, Object> readSummary(String json) {
+        if (!StringUtils.hasText(json)) return Map.of();
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    private String projectRef() {
+        String projectRef = MultiTenancyContext.getAppCode();
+        if (!StringUtils.hasText(projectRef)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Project context is required");
+        }
+        return projectRef;
+    }
+
+    private static String canonical(String workerName) {
+        return workerName.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String str(Object value) {
+        return value instanceof String text && StringUtils.hasText(text) ? text : null;
+    }
+
+    private record OwnedWorker(String workerName, AppDeployment deployment, Map<String, Object> summary) {
+    }
+}

--- a/src/main/java/ai/nubase/deploy/service/CloudflareAppWorkerDeployer.java
+++ b/src/main/java/ai/nubase/deploy/service/CloudflareAppWorkerDeployer.java
@@ -129,6 +129,48 @@ public class CloudflareAppWorkerDeployer implements AppWorkerDeployer {
         return new AssetUpload(completionJwt, manifestHash, files.size());
     }
 
+    @Override
+    public AppWorkerInfo get(String workerName) {
+        validateConfig();
+        String name = normalizeWorkerName(workerName);
+        try {
+            Map<String, Object> result = executeJson(new Request.Builder()
+                    .url(scriptUrl(name))
+                    .get()
+                    .header("Authorization", "Bearer " + cf().getApiToken())
+                    .build(), true);
+            if (result == null) {
+                return new AppWorkerInfo(name, false, Map.of());
+            }
+            return new AppWorkerInfo(name, true, result);
+        } catch (IOException e) {
+            throw new AppWorkerDeploymentException("Failed to read app worker " + name + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void delete(String workerName) {
+        validateConfig();
+        String name = normalizeWorkerName(workerName);
+        Request request = new Request.Builder()
+                .url(scriptUrl(name) + "?force=true")
+                .delete()
+                .header("Authorization", "Bearer " + cf().getApiToken())
+                .build();
+        try (Response ignored = executeCloudflare(request, true)) {
+            // A null/closed response (404) means the script was already gone — idempotent success.
+        } catch (IOException e) {
+            throw new AppWorkerDeploymentException("Failed to delete app worker " + name + ": " + e.getMessage(), e);
+        }
+    }
+
+    private String scriptUrl(String name) {
+        return apiBase()
+                + "/accounts/" + cf().getAccountId()
+                + "/workers/dispatch/namespaces/" + cf().getDispatchNamespace()
+                + "/scripts/" + name;
+    }
+
     private void uploadWorker(AppWorkerDeploymentRequest request, String workerName, String assetCompletionJwt) throws IOException {
         Map<String, AppWorkerDeploymentRequest.AppWorkerFile> serverFiles = new LinkedHashMap<>();
         for (AppWorkerDeploymentRequest.AppWorkerFile file : request.serverFiles() == null ? List.<AppWorkerDeploymentRequest.AppWorkerFile>of() : request.serverFiles()) {
@@ -242,7 +284,12 @@ public class CloudflareAppWorkerDeployer implements AppWorkerDeployer {
     }
 
     private Map<String, Object> executeJson(Request request) throws IOException {
-        try (Response response = executeCloudflare(request)) {
+        return executeJson(request, false);
+    }
+
+    private Map<String, Object> executeJson(Request request, boolean allowNotFound) throws IOException {
+        try (Response response = executeCloudflare(request, allowNotFound)) {
+            if (response == null) return null;
             String body = response.body() == null ? "" : response.body().string();
             if (!StringUtils.hasText(body)) return Map.of();
             Map<String, Object> envelope = objectMapper.readValue(body, new TypeReference<>() {});
@@ -257,9 +304,21 @@ public class CloudflareAppWorkerDeployer implements AppWorkerDeployer {
     }
 
     private Response executeCloudflare(Request request) throws IOException {
+        return executeCloudflare(request, false);
+    }
+
+    /**
+     * Execute a Cloudflare request with retry on 429/5xx. When {@code allowNotFound} is true a
+     * 404 returns {@code null} (caller treats it as absent) instead of throwing.
+     */
+    private Response executeCloudflare(Request request, boolean allowNotFound) throws IOException {
         IOException last = null;
         for (int attempt = 1; attempt <= 3; attempt++) {
             Response response = httpClient().newCall(request).execute();
+            if (allowNotFound && response.code() == 404) {
+                response.close();
+                return null;
+            }
             if (response.code() == 429 || response.code() >= 500) {
                 String body = response.body() == null ? "" : response.body().string();
                 response.close();

--- a/src/main/java/ai/nubase/deploy/service/DisabledAppWorkerDeployer.java
+++ b/src/main/java/ai/nubase/deploy/service/DisabledAppWorkerDeployer.java
@@ -7,8 +7,20 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(value = "nubase.functions.enabled", havingValue = "false")
 public class DisabledAppWorkerDeployer implements AppWorkerDeployer {
 
+    private static final String DISABLED = "App worker deployment requires nubase.functions.enabled=true";
+
     @Override
     public AppWorkerDeploymentResult deploy(AppWorkerDeploymentRequest request) {
-        throw new AppWorkerDeploymentException("App worker deployment requires nubase.functions.enabled=true");
+        throw new AppWorkerDeploymentException(DISABLED);
+    }
+
+    @Override
+    public AppWorkerInfo get(String workerName) {
+        throw new AppWorkerDeploymentException(DISABLED);
+    }
+
+    @Override
+    public void delete(String workerName) {
+        throw new AppWorkerDeploymentException(DISABLED);
     }
 }

--- a/src/main/java/ai/nubase/mcp/tools/DeploymentsMcpTools.java
+++ b/src/main/java/ai/nubase/mcp/tools/DeploymentsMcpTools.java
@@ -3,6 +3,7 @@ package ai.nubase.mcp.tools;
 import ai.nubase.common.context.MultiTenancyContext;
 import ai.nubase.deploy.service.AppDeploymentService;
 import ai.nubase.deploy.service.AppDeploymentRollbackService;
+import ai.nubase.deploy.service.AppWorkerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ public class DeploymentsMcpTools {
 
     private final AppDeploymentService deploymentService;
     private final AppDeploymentRollbackService rollbackService;
+    private final AppWorkerService appWorkerService;
 
     @Tool(description = "List recent app deployments for the current project. Parameters: limit optional default 50. Read-only.")
     public Object deploymentsList(Integer limit) {
@@ -44,5 +46,32 @@ public class DeploymentsMcpTools {
         }
         if (id == null || id.isBlank()) return Map.of("success", false, "error", "id is required");
         return rollbackService.rollback(UUID.fromString(id));
+    }
+
+    @Tool(description = "List the app workers (Cloudflare Workers) this project has deployed, with their latest version, preview URL and deployment status. Scoped to the current project. Read-only.")
+    public Object appWorkersList() {
+        return appWorkerService.list();
+    }
+
+    @Tool(description = "Get one deployed app worker for this project, enriched with live provider state. Parameters: workerName required. Read-only.")
+    public Object appWorkerStatus(String workerName) {
+        if (workerName == null || workerName.isBlank()) {
+            return Map.of("success", false, "error", "workerName is required");
+        }
+        return appWorkerService.get(workerName);
+    }
+
+    @Tool(description = "Delete (undeploy) one app worker owned by this project. Parameters: workerName required. Write operation; requires service_role project context and only affects workers this project has deployed.")
+    public Object appWorkerDelete(String workerName) {
+        if (!MultiTenancyContext.isServiceRole()) {
+            return Map.of(
+                    "success", false,
+                    "error", "appWorkerDelete requires service_role project context"
+            );
+        }
+        if (workerName == null || workerName.isBlank()) {
+            return Map.of("success", false, "error", "workerName is required");
+        }
+        return appWorkerService.delete(workerName);
     }
 }

--- a/src/test/java/ai/nubase/deploy/service/AppWorkerDeployServiceTest.java
+++ b/src/test/java/ai/nubase/deploy/service/AppWorkerDeployServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -21,6 +22,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -131,6 +133,55 @@ class AppWorkerDeployServiceTest {
         assertThat(steps.getAllValues().get(2).stepName()).isEqualTo("cloudflare_app_worker_deploy");
         assertThat(steps.getAllValues().get(2).status()).isEqualTo(AppDeploymentStep.STATUS_FAILED);
         verify(deploymentService).complete(eq(deploymentId), any(CompleteDeploymentRequest.class));
+    }
+
+    @Test
+    void rejectsWorkerNameNotNamespacedUnderAppCode() {
+        var metadata = new AppWorkerDeployMetadata(
+                "appabc",
+                "v1",
+                "someone-elses-worker",
+                "server/index.js",
+                "server/index.js",
+                "dist/client",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertThatThrownBy(() -> service.deploy(metadata, List.of(serverFile()), List.of()))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("workerName must equal the project appCode");
+
+        verify(deployer, org.mockito.Mockito.never()).deploy(any());
+        verify(deploymentService, org.mockito.Mockito.never()).create(any());
+    }
+
+    @Test
+    void allowsWorkerNameNamespacedUnderAppCode() {
+        UUID deploymentId = UUID.randomUUID();
+        when(deploymentService.create(any(CreateDeploymentRequest.class))).thenReturn(new DeploymentResponse(
+                deploymentId, "appabc", "appabc", AppDeployment.STATUS_RUNNING, null, Map.of(),
+                null, null, "v1", Instant.now(), Instant.now(), null
+        ));
+        when(deployer.deploy(any(AppWorkerDeploymentRequest.class))).thenReturn(new AppWorkerDeploymentResult(
+                "cloudflare", "appabc-preview", "https://appabc-preview.ottermind.app", "deployed",
+                "asset-hash", 0, Instant.parse("2026-06-17T00:00:00Z")
+        ));
+        var metadata = new AppWorkerDeployMetadata(
+                "appabc", "v1", "appabc-preview", "server/index.js", "server/index.js",
+                "dist/client", null, null, null, null, null, null
+        );
+
+        var response = service.deploy(metadata, List.of(serverFile()), List.of());
+
+        assertThat(response.status()).isEqualTo("deployed");
+        ArgumentCaptor<AppWorkerDeploymentRequest> request = ArgumentCaptor.forClass(AppWorkerDeploymentRequest.class);
+        verify(deployer).deploy(request.capture());
+        assertThat(request.getValue().workerName()).isEqualTo("appabc-preview");
     }
 
     private AppWorkerDeployMetadata metadata() {

--- a/src/test/java/ai/nubase/deploy/service/AppWorkerServiceTest.java
+++ b/src/test/java/ai/nubase/deploy/service/AppWorkerServiceTest.java
@@ -1,0 +1,191 @@
+package ai.nubase.deploy.service;
+
+import ai.nubase.common.context.MultiTenancyContext;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerDeleteResponse;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerDetail;
+import ai.nubase.deploy.dto.AppDeploymentDtos.AppWorkerSummary;
+import ai.nubase.deploy.dto.AppDeploymentDtos.CompleteDeploymentRequest;
+import ai.nubase.deploy.dto.AppDeploymentDtos.CreateDeploymentRequest;
+import ai.nubase.deploy.dto.AppDeploymentDtos.DeploymentResponse;
+import ai.nubase.deploy.dto.AppDeploymentDtos.RecordDeploymentStepRequest;
+import ai.nubase.metadata.entity.AppDeployment;
+import ai.nubase.metadata.repository.AppDeploymentRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AppWorkerServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private AppDeploymentRepository deploymentRepository;
+    private AppDeploymentService deploymentService;
+    private AppWorkerDeployer deployer;
+    private AppWorkerService service;
+
+    @BeforeEach
+    void setUp() {
+        MultiTenancyContext.setContext(MultiTenancyContext.ContextData.builder()
+                .appCode("appabc")
+                .serviceRole(true)
+                .build());
+        deploymentRepository = mock(AppDeploymentRepository.class);
+        deploymentService = mock(AppDeploymentService.class);
+        deployer = mock(AppWorkerDeployer.class);
+        service = new AppWorkerService(deploymentRepository, deploymentService, deployer, objectMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MultiTenancyContext.clear();
+    }
+
+    @Test
+    void listReturnsLatestDeploymentPerOwnedWorkerSortedByName() {
+        when(deploymentRepository.findByProjectRefOrderByCreatedAtDesc(eq("appabc"), any(Pageable.class)))
+                .thenReturn(List.of(
+                        appWorkerDeployment("appabc", "v2", AppDeployment.STATUS_SUCCEEDED),
+                        appWorkerDeployment("widget", "v1", AppDeployment.STATUS_SUCCEEDED),
+                        appWorkerDeployment("appabc", "v1", AppDeployment.STATUS_SUCCEEDED),
+                        nonWorkerDeployment()
+                ));
+
+        List<AppWorkerSummary> workers = service.list();
+
+        assertThat(workers).extracting(AppWorkerSummary::workerName)
+                .containsExactly("appabc", "widget");
+        // newest deployment wins (list is newest-first, putIfAbsent keeps the first seen)
+        assertThat(workers.get(0).version()).isEqualTo("v2");
+        assertThat(workers.get(0).previewHost()).isEqualTo("appabc.ottermind.app");
+        assertThat(workers.get(0).publicUrl()).isEqualTo("https://appabc.ottermind.app");
+    }
+
+    @Test
+    void getEnrichesOwnedWorkerWithLiveProviderState() {
+        when(deploymentRepository.findByProjectRefOrderByCreatedAtDesc(eq("appabc"), any(Pageable.class)))
+                .thenReturn(List.of(appWorkerDeployment("appabc", "v1", AppDeployment.STATUS_SUCCEEDED)));
+        when(deployer.get("appabc")).thenReturn(new AppWorkerInfo("appabc", true, Map.of("id", "appabc")));
+
+        AppWorkerDetail detail = service.get("APPABC");
+
+        assertThat(detail.existsOnProvider()).isTrue();
+        assertThat(detail.worker().workerName()).isEqualTo("appabc");
+        assertThat(detail.provider()).isEqualTo(Map.of("id", "appabc"));
+        verify(deployer).get("appabc");
+    }
+
+    @Test
+    void getRejectsWorkerNotOwnedByProject() {
+        when(deploymentRepository.findByProjectRefOrderByCreatedAtDesc(eq("appabc"), any(Pageable.class)))
+                .thenReturn(List.of(appWorkerDeployment("appabc", "v1", AppDeployment.STATUS_SUCCEEDED)));
+
+        assertThatThrownBy(() -> service.get("someone-elses-worker"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("not found");
+        verify(deployer, never()).get(any());
+    }
+
+    @Test
+    void deleteUndeploysOwnedWorkerAndRecordsAudit() {
+        UUID auditId = UUID.randomUUID();
+        when(deploymentRepository.findByProjectRefOrderByCreatedAtDesc(eq("appabc"), any(Pageable.class)))
+                .thenReturn(List.of(appWorkerDeployment("appabc", "v1", AppDeployment.STATUS_SUCCEEDED)));
+        when(deploymentService.create(any(CreateDeploymentRequest.class))).thenReturn(auditResponse(auditId));
+        when(deploymentService.complete(eq(auditId), any(CompleteDeploymentRequest.class))).thenReturn(auditResponse(auditId));
+
+        AppWorkerDeleteResponse response = service.delete("appabc");
+
+        assertThat(response.deleted()).isTrue();
+        assertThat(response.workerName()).isEqualTo("appabc");
+        assertThat(response.auditDeploymentId()).isEqualTo(auditId);
+        verify(deployer).delete("appabc");
+        verify(deploymentService).recordStep(eq(auditId), any(RecordDeploymentStepRequest.class));
+        verify(deploymentService).complete(eq(auditId), any(CompleteDeploymentRequest.class));
+    }
+
+    @Test
+    void deleteRejectsWorkerNotOwnedByProject() {
+        when(deploymentRepository.findByProjectRefOrderByCreatedAtDesc(eq("appabc"), any(Pageable.class)))
+                .thenReturn(List.of(appWorkerDeployment("appabc", "v1", AppDeployment.STATUS_SUCCEEDED)));
+
+        assertThatThrownBy(() -> service.delete("not-mine"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("not found");
+        verify(deployer, never()).delete(any());
+        verify(deploymentService, never()).create(any());
+    }
+
+    private AppDeployment appWorkerDeployment(String workerName, String version, String status) {
+        return AppDeployment.builder()
+                .id(UUID.randomUUID())
+                .projectRef("appabc")
+                .appName("appabc")
+                .status(status)
+                .publicUrl("https://" + workerName + ".ottermind.app")
+                .manifestSummary(json(Map.of(
+                        "type", "app_worker",
+                        "appCode", "appabc",
+                        "version", version,
+                        "workerName", workerName,
+                        "previewHost", workerName + ".ottermind.app"
+                )))
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .completedAt(Instant.now())
+                .build();
+    }
+
+    private AppDeployment nonWorkerDeployment() {
+        return AppDeployment.builder()
+                .id(UUID.randomUUID())
+                .projectRef("appabc")
+                .appName("appabc")
+                .status(AppDeployment.STATUS_SUCCEEDED)
+                .manifestSummary(json(Map.of("functions", List.of("hello"))))
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    private DeploymentResponse auditResponse(UUID id) {
+        return new DeploymentResponse(
+                id,
+                "appabc",
+                "appabc",
+                AppDeployment.STATUS_RUNNING,
+                null,
+                Map.of(),
+                null,
+                null,
+                null,
+                Instant.now(),
+                Instant.now(),
+                null
+        );
+    }
+
+    private String json(Map<String, Object> value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/ai/nubase/deploy/service/CloudflareAppWorkerDeployerTest.java
+++ b/src/test/java/ai/nubase/deploy/service/CloudflareAppWorkerDeployerTest.java
@@ -139,6 +139,74 @@ class CloudflareAppWorkerDeployerTest {
         }
     }
 
+    @Test
+    void getReturnsLiveScriptDetailsFromDispatchNamespace() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200).setBody("""
+                    {"success":true,"result":{"id":"appabc","created_on":"2026-06-17T00:00:00Z"}}
+                    """));
+            server.start();
+            var deployer = new CloudflareAppWorkerDeployer(props(server), new ObjectMapper());
+
+            AppWorkerInfo info = deployer.get("AppABC");
+
+            assertThat(info.exists()).isTrue();
+            assertThat(info.workerName()).isEqualTo("appabc");
+            assertThat(info.details()).containsEntry("id", "appabc");
+
+            var request = server.takeRequest();
+            assertThat(request.getMethod()).isEqualTo("GET");
+            assertThat(request.getPath())
+                    .isEqualTo("/client/v4/accounts/acct/workers/dispatch/namespaces/ns/scripts/appabc");
+            assertThat(request.getHeader("Authorization")).isEqualTo("Bearer token");
+        }
+    }
+
+    @Test
+    void getReportsMissingWorkerWhenProviderReturns404() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(404).setBody(
+                    "{\"success\":false,\"errors\":[{\"code\":10007,\"message\":\"workers.api.error.script_not_found\"}]}"));
+            server.start();
+            var deployer = new CloudflareAppWorkerDeployer(props(server), new ObjectMapper());
+
+            AppWorkerInfo info = deployer.get("appabc");
+
+            assertThat(info.exists()).isFalse();
+            assertThat(info.details()).isEmpty();
+        }
+    }
+
+    @Test
+    void deleteRemovesScriptFromDispatchNamespace() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"success\":true}"));
+            server.start();
+            var deployer = new CloudflareAppWorkerDeployer(props(server), new ObjectMapper());
+
+            deployer.delete("appabc");
+
+            var request = server.takeRequest();
+            assertThat(request.getMethod()).isEqualTo("DELETE");
+            assertThat(request.getPath())
+                    .isEqualTo("/client/v4/accounts/acct/workers/dispatch/namespaces/ns/scripts/appabc?force=true");
+        }
+    }
+
+    @Test
+    void deleteIsIdempotentWhenWorkerAlreadyAbsent() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(404).setBody(
+                    "{\"success\":false,\"errors\":[{\"code\":10007,\"message\":\"script_not_found\"}]}"));
+            server.start();
+            var deployer = new CloudflareAppWorkerDeployer(props(server), new ObjectMapper());
+
+            deployer.delete("appabc");
+
+            assertThat(server.getRequestCount()).isEqualTo(1);
+        }
+    }
+
     private EdgeFunctionExecutorProperties props(MockWebServer server) {
         EdgeFunctionExecutorProperties props = new EdgeFunctionExecutorProperties();
         props.getCloudflare().setAccountId("acct");

--- a/src/test/java/ai/nubase/mcp/tools/McpConfigTest.java
+++ b/src/test/java/ai/nubase/mcp/tools/McpConfigTest.java
@@ -20,7 +20,8 @@ class McpConfigTest {
         GatewayMcpTools gatewayMcpTools = new GatewayMcpTools(mock(ai.nubase.ai.gateway.repository.ApiKeyRepository.class));
         DeploymentsMcpTools deploymentsMcpTools = new DeploymentsMcpTools(
                 mock(ai.nubase.deploy.service.AppDeploymentService.class),
-                mock(ai.nubase.deploy.service.AppDeploymentRollbackService.class)
+                mock(ai.nubase.deploy.service.AppDeploymentRollbackService.class),
+                mock(ai.nubase.deploy.service.AppWorkerService.class)
         );
         FunctionsMcpTools functionsMcpTools = mock(FunctionsMcpTools.class);
         CronMcpTools cronMcpTools = mock(CronMcpTools.class);

--- a/src/test/java/ai/nubase/mcp/tools/RemoteAdminMcpToolsTest.java
+++ b/src/test/java/ai/nubase/mcp/tools/RemoteAdminMcpToolsTest.java
@@ -105,12 +105,27 @@ class RemoteAdminMcpToolsTest {
     void deploymentRollbackRequiresServiceRole() {
         AppDeploymentService deploymentService = mock(AppDeploymentService.class);
         AppDeploymentRollbackService rollbackService = mock(AppDeploymentRollbackService.class);
-        Object result = new DeploymentsMcpTools(deploymentService, rollbackService)
+        Object result = new DeploymentsMcpTools(deploymentService, rollbackService,
+                mock(ai.nubase.deploy.service.AppWorkerService.class))
                 .deploymentRollback("4e581dbc-07f8-477c-8db1-41b89d65a36e");
 
         assertThat(result).isInstanceOf(Map.class);
         assertThat(asMap(result)).containsEntry("success", false);
         verifyNoInteractions(rollbackService);
+    }
+
+    @Test
+    void appWorkerDeleteRequiresServiceRole() {
+        AppDeploymentService deploymentService = mock(AppDeploymentService.class);
+        AppDeploymentRollbackService rollbackService = mock(AppDeploymentRollbackService.class);
+        ai.nubase.deploy.service.AppWorkerService appWorkerService =
+                mock(ai.nubase.deploy.service.AppWorkerService.class);
+        Object result = new DeploymentsMcpTools(deploymentService, rollbackService, appWorkerService)
+                .appWorkerDelete("my-app");
+
+        assertThat(result).isInstanceOf(Map.class);
+        assertThat(asMap(result)).containsEntry("success", false);
+        verifyNoInteractions(appWorkerService);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Adds a control-plane management layer for deployed **app workers** (Cloudflare full-app workers — server module + bundled assets on a shared Workers-for-Platforms dispatch namespace). Previously the feature only had a deploy endpoint; you could ship an app worker but not list, inspect, or undeploy one. This PR closes that loop and wires it through MCP and the `nubase` skill.

## What's included

**Backend (control plane)**
- `AppWorkerDeployer` gains 404-tolerant `get` / `delete`; `CloudflareAppWorkerDeployer` implements them via dispatch-namespace `GET` / `DELETE` (get → `exists=false` when absent, delete → idempotent). `executeCloudflare` refactored with an `allowNotFound` variant.
- New `AppWorkerService` does tenant-scoped `list` / `get` / `delete`.
- `AppDeploymentAdminController` (`@RequireServiceRole`) adds `GET /deployments/admin/v1/app-workers`, `GET .../{workerName}`, `DELETE .../{workerName}`.

**MCP**
- `DeploymentsMcpTools`: `appWorkersList` (read), `appWorkerStatus` (read, with live provider state), `appWorkerDelete` (write, gated on `service_role`).
- Frontend bridge: `app_workers_list` / `app_worker_status` / `app_worker_delete` in `tools.ts` + `nubase-client.ts`.

**Skill**
- New `references/app-workers.md`, linked from `SKILL.md` (reference list + read/write tool inventories).

## Tenant safety

The dispatch namespace is **shared across all tenants**, so management never enumerates the namespace — ownership is derived solely from the project's own `app_deployments` history (`manifest_summary.type == "app_worker"`, latest per workerName, case-insensitive). `requireOwned()` rejects any worker not owned by the calling project, so a project can never read or delete another tenant's worker. Deletes write an `app_worker_delete` audit row.

Additionally, the deploy path now rejects a custom `workerName` that isn't namespaced under the project: it must equal `appCode` or start with `appCode-` (403 otherwise), closing a pre-existing cross-tenant naming-collision gap at the deploy boundary.

## Tests

- New `AppWorkerServiceTest` (ownership scoping + list/get/delete), extended `CloudflareAppWorkerDeployerTest` (get/delete + 404 cases), extended `AppWorkerDeployServiceTest` (workerName prefix accept/reject), `appWorkerDelete` service-role parity in `RemoteAdminMcpToolsTest`, updated `McpConfigTest` constructor.
- Java: `mvn -o test` on the affected classes → all green. Frontend: `tsc` build clean + `node --test` → 118 passed (incl. new app-worker tool dispatch test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)