### PR TITLE
fix(auth): reject backslash redirect paths

### DIFF
--- a/src/main/java/ai/nubase/auth/service/RedirectUrlValidator.java
+++ b/src/main/java/ai/nubase/auth/service/RedirectUrlValidator.java
@@ -56,8 +56,11 @@ public class RedirectUrlValidator {
         }
         AuthConfig.RedirectSettings cfg = effectiveAuthConfig.redirect();
 
-        // Relative path (same-origin), but reject protocol-relative "//host".
-        if (redirectTo.startsWith("/") && !redirectTo.startsWith("//")) {
+        // Relative path (same-origin), but reject protocol-relative "//host" and
+        // backslashes, which browsers normalize to slashes for special URL schemes.
+        if (redirectTo.startsWith("/")
+                && !redirectTo.startsWith("//")
+                && redirectTo.indexOf('\\') < 0) {
             return true;
         }
 

--- a/src/test/java/ai/nubase/auth/service/RedirectUrlValidatorTest.java
+++ b/src/test/java/ai/nubase/auth/service/RedirectUrlValidatorTest.java
@@ -28,12 +28,14 @@ class RedirectUrlValidatorTest {
     }
 
     @Test
-    @DisplayName("relative paths are allowed; protocol-relative URLs are rejected")
+    @DisplayName("relative paths are allowed; cross-origin path forms are rejected")
     void relativePaths() {
         RedirectUrlValidator v = validator(new AuthConfig());
         assertThat(v.isAllowed("/dashboard")).isTrue();
         assertThat(v.isAllowed("/auth/callback?x=1")).isTrue();
         assertThat(v.isAllowed("//evil.com/phish")).isFalse();   // protocol-relative
+        assertThat(v.isAllowed("/\\evil.com/phish")).isFalse(); // browser-normalized to //evil.com
+        assertThat(v.isAllowed("/safe\\path")).isFalse();       // reject ambiguous separators
     }
 
     @Test


### PR DESCRIPTION
## Summary

- reject backslashes in same-origin relative redirect targets
- add regression coverage for browser-normalized and ambiguous path separators

## Why

The relative redirect check rejected protocol-relative paths beginning with `//`, but still accepted paths containing backslashes. Browsers normalize backslashes to slashes for HTTP(S) URLs, so a value that appears relative to the server can resolve to a different origin in the browser.

## Impact

Unsafe redirect path forms are now rejected and fall back through the existing safe redirect behavior. Ordinary relative paths such as `/dashboard` remain supported.

## Validation

```text
mvn -Dtest=RedirectUrlValidatorTest test
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
