### PR TITLE
fix(assets): honor ETag on HEAD requests

### DIFF
--- a/src/main/java/ai/nubase/assets/controller/AssetsPublicController.java
+++ b/src/main/java/ai/nubase/assets/controller/AssetsPublicController.java
@@ -65,9 +65,15 @@ public class AssetsPublicController {
      * HEAD /assets/v1/{path}
      */
     @RequestMapping(value = "/**", method = RequestMethod.HEAD)
-    public ResponseEntity<Void> head(HttpServletRequest request) {
+    public ResponseEntity<Void> head(
+            @RequestHeader(value = "If-None-Match", required = false) String ifNoneMatch,
+            HttpServletRequest request
+    ) {
         AssetFile file = assetsService.getPublicFileOrThrow(RequestUtil.extractPathVariable(request));
         HttpHeaders headers = buildHeaders(file);
+        if (etagMatches(ifNoneMatch, file.getEtag())) {
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).headers(headers).build();
+        }
         headers.setContentLength(file.getSizeBytes());
         return ResponseEntity.ok().headers(headers).build();
     }
@@ -119,3 +125,4 @@ public class AssetsPublicController {
         return v.startsWith("\"") ? v : "\"" + v + "\"";
     }
 }
+    

--- a/src/test/java/ai/nubase/assets/controller/AssetsPublicControllerTest.java
+++ b/src/test/java/ai/nubase/assets/controller/AssetsPublicControllerTest.java
@@ -1,0 +1,35 @@
+package ai.nubase.assets.controller;
+
+import ai.nubase.assets.entity.AssetFile;
+import ai.nubase.assets.service.AssetsService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.HandlerMapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AssetsPublicControllerTest {
+
+    @Test
+    void headReturnsNotModifiedWhenEtagMatches() {
+        AssetsService assetsService = mock(AssetsService.class);
+        AssetsPublicController controller = new AssetsPublicController(assetsService);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE)).thenReturn("/assets/v1/**");
+        when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).thenReturn("/assets/v1/app.css");
+        when(assetsService.getPublicFileOrThrow("app.css"))
+                .thenReturn(AssetFile.builder().etag("asset-v1").sizeBytes(42).build());
+
+        ResponseEntity<Void> response = controller.head("W/\"asset-v1\"", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_MODIFIED);
+        assertThat(response.getHeaders().getETag()).isEqualTo("\"asset-v1\"");
+        verify(assetsService).getPublicFileOrThrow("app.css");
+    }
+}
+  


### PR DESCRIPTION
## What changed
- Honor `If-None-Match` on asset `HEAD` requests.
- Return `304 Not Modified` with the matching ETag instead of an unconditional 200 response.
- Add a controller regression test for weak ETag matching.

## Validation
- `git diff --check`
- Not run locally: Maven and the Maven Wrapper are unavailable in this environment.