### PR TITLE
fix(auth): normalize platform emails with Locale.ROOT

### DIFF
--- a/src/main/java/ai/nubase/auth/service/PlatformAuthService.java
+++ b/src/main/java/ai/nubase/auth/service/PlatformAuthService.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -135,7 +136,7 @@ public class PlatformAuthService {
 
     @Transactional("metadataTransactionManager")
     public AuthOutcome signUp(PlatformSignUpRequest request) {
-        String email = request.getEmail().trim().toLowerCase();
+        String email = request.getEmail().trim().toLowerCase(Locale.ROOT);
 
         // An account that exists but never confirmed its email is an *unfinished* signup, not a real
         // conflict — the email owner hasn't been proven yet. Treat a repeat signup as "continue": refresh
@@ -188,7 +189,7 @@ public class PlatformAuthService {
     @Transactional("metadataTransactionManager")
     public AuthOutcome signIn(PlatformSignInRequest request) {
         String email = request.getEmail().trim();
-        String rlKey = "platform_login:" + email.toLowerCase();
+        String rlKey = "platform_login:" + email.toLowerCase(Locale.ROOT);
         // Throttle online password guessing against Studio accounts (mirrors tenant auth).
         rateLimiter.assertNotLockedOut(rlKey);
         Optional<PlatformUser> maybe = platformUserRepository.findByEmailIgnoreCase(email);
@@ -222,7 +223,7 @@ public class PlatformAuthService {
      */
     @Transactional("metadataTransactionManager")
     public PlatformAuthResponse verifyEmail(String rawEmail, String code) {
-        String email = rawEmail == null ? "" : rawEmail.trim().toLowerCase();
+        String email = rawEmail == null ? "" : rawEmail.trim().toLowerCase(Locale.ROOT);
         PlatformUser user = platformUserRepository.findByEmailIgnoreCase(email)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid or expired code"));
         if (!Boolean.TRUE.equals(user.getIsActive())) {
@@ -241,7 +242,7 @@ public class PlatformAuthService {
     /** Re-send a verification code for an unverified account. No-op (silent) for unknown/verified emails. */
     @Transactional("metadataTransactionManager")
     public void resendVerification(String rawEmail) {
-        String email = rawEmail == null ? "" : rawEmail.trim().toLowerCase();
+        String email = rawEmail == null ? "" : rawEmail.trim().toLowerCase(Locale.ROOT);
         platformUserRepository.findByEmailIgnoreCase(email).ifPresent(user -> {
             if (Boolean.TRUE.equals(user.getIsActive()) && user.getEmailVerifiedAt() == null) {
                 otpService.issue(email, Purpose.LOGIN);
@@ -282,7 +283,7 @@ public class PlatformAuthService {
      */
     @Transactional("metadataTransactionManager")
     public PlatformAuthResponse oauthSignIn(String rawEmail, String fullName) {
-        String email = rawEmail == null ? null : rawEmail.trim().toLowerCase();
+        String email = rawEmail == null ? null : rawEmail.trim().toLowerCase(Locale.ROOT);
         if (email == null || email.isEmpty()) {
             throw new IllegalArgumentException("OAuth identity has no email address");
         }
@@ -400,3 +401,4 @@ public class PlatformAuthService {
                 .build();
     }
 }
+    

--- a/src/main/java/ai/nubase/auth/service/PlatformOtpService.java
+++ b/src/main/java/ai/nubase/auth/service/PlatformOtpService.java
@@ -14,6 +14,140 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Issues and verifies email one-time codes for platform (Studio) developer accounts.
+ *
+ * <p>Self-contained platform path that reuses the context-free pieces of the tenant auth stack:
+ * {@link TokenGenerator} (numeric code + SHA-256) and {@link RateLimiterService} (keyed by action,
+ * tenant resolves to {@code "_"} when there is no request context). Codes are stored only as a
+ * SHA-256 hash in {@code platform_one_time_tokens}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PlatformOtpService {
+
+    static final String LOCAL_DEVELOPMENT_CODE = "123456";
+
+    private final PlatformOneTimeTokenRepository tokenRepository;
+    private final TokenGenerator tokenGenerator;
+    private final RateLimiterService rateLimiter;
+    private final PlatformEmailService emailService;
+    private final Environment environment;
+
+    @Value("${nubase.platform.otp.length:6}")
+    private int codeLength;
+
+    @Value("${nubase.platform.otp.expiration-seconds:600}")
+    private long expirationSeconds;
+
+    /**
+     * Generate a code and persist its hash, replacing any pending code for this email and purpose.
+     * Development profiles use a fixed code without sending email; other profiles email a random code.
+     */
+    @Transactional("metadataTransactionManager")
+    public void issue(String rawEmail, Purpose purpose) {
+        String email = normalize(rawEmail);
+        String storageKey = storageKey(purpose);
+        rateLimiter.checkRate("platform_otp:" + storageKey, email);
+
+        boolean localDevelopment = isLocalDevelopment();
+        String code = localDevelopment
+                ? LOCAL_DEVELOPMENT_CODE
+                : tokenGenerator.generateNumericOTP(codeLength);
+        // Atomic upsert on the (email, purpose) unique key: replaces any pending code in one statement,
+        // so two concurrent issue() calls (e.g. double-clicked "resend") can't race into a constraint
+        // violation, and there's no Hibernate insert-before-delete flush-ordering hazard.
+        tokenRepository.upsert(email, storageKey,
+                tokenGenerator.sha256(code), Instant.now().plusSeconds(expirationSeconds));
+
+        if (localDevelopment) {
+            log.info("Platform OTP email skipped for local development (purpose={})", purpose);
+            return;
+        }
+        emailService.sendOtp(email, code, purpose, expirationSeconds);
+    }
+
+    /**
+     * Verify a code for the given email+purpose. Consumes the code on success.
+     *
+     * @throws IllegalArgumentException if no pending code, the code is wrong, or it has expired
+     */
+    @Transactional("metadataTransactionManager")
+    public void verify(String rawEmail, Purpose purpose, String code) {
+        verifyAny(rawEmail, code, purpose);
+    }
+
+    /**
+     * Verify a code against any of the given purposes, consuming the matching code on success.
+     *
+     * <p>Checks each purpose in turn and only throws <em>once</em>, at the end, if none match. This
+     * matters because a mid-method throw inside this {@code @Transactional} would mark the caller's
+     * shared transaction rollback-only — so we must not "try then catch" across purposes.
+     *
+     * @throws IllegalArgumentException if no purpose has a valid, unexpired, matching code
+     */
+    @Transactional("metadataTransactionManager")
+    public void verifyAny(String rawEmail, String code, Purpose... purposes) {
+        String email = normalize(rawEmail);
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("Verification code is required");
+        }
+        String hash = tokenGenerator.sha256(code.trim());
+        for (Purpose purpose : purposes) {
+            Optional<PlatformOneTimeToken> maybe =
+                    tokenRepository.findByEmailIgnoreCaseAndPurpose(email, storageKey(purpose));
+            if (maybe.isEmpty()) {
+                continue;
+            }
+            PlatformOneTimeToken token = maybe.get();
+            if (token.getExpiresAt().isBefore(Instant.now())) {
+                tokenRepository.delete(token); // prune the expired code, keep looking
+                continue;
+            }
+            if (token.getTokenHash().equals(hash)) {
+                tokenRepository.delete(token);
+                return;
+            }
+        }
+        throw new IllegalArgumentException("Invalid or expired code");
+    }
+
+    private static String normalize(String email) {
+        return email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isLocalDevelopment() {
+        return environment.acceptsProfiles(Profiles.of("dev", "local"));
+    }
+
+    private static String storageKey(Purpose purpose) {
+        return switch (purpose) {
+            case SIGNUP -> PlatformOneTimeToken.PURPOSE_SIGNUP;
+            case LOGIN -> PlatformOneTimeToken.PURPOSE_LOGIN;
+            case PASSWORD_CHANGE -> PlatformOneTimeToken.PURPOSE_PASSWORD_CHANGE;
+        };
+    }
+}
+    package ai.nubase.auth.service;
+
+import ai.nubase.auth.util.TokenGenerator;
+import ai.nubase.metadata.entity.PlatformOneTimeToken;
+import ai.nubase.metadata.repository.PlatformOneTimeTokenRepository;
+import ai.nubase.platform.mail.PlatformEmailService;
+import ai.nubase.platform.mail.PlatformEmailService.Purpose;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
 import java.util.Optional;
 
 /**

--- a/src/test/java/ai/nubase/auth/service/PlatformOtpServiceTest.java
+++ b/src/test/java/ai/nubase/auth/service/PlatformOtpServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -95,6 +96,19 @@ class PlatformOtpServiceTest {
     }
 
     @Test
+    void issueNormalizesEmailIndependentlyOfDefaultLocale() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            service.issue("ADMIN@EXAMPLE.COM", Purpose.LOGIN);
+
+            verify(rateLimiter).checkRate("platform_otp:login", "admin@example.com");
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    @Test
     void verifyWrongCodeThrowsAndKeepsToken() {
         PlatformOneTimeToken stored = token(
                 "signup",
@@ -140,3 +154,4 @@ class PlatformOtpServiceTest {
                 .build();
     }
 }
+    


### PR DESCRIPTION
## What changed
- Normalize platform account and OTP email addresses with `Locale.ROOT`.
- Keep rate-limit keys stable regardless of the server default locale.
- Add a Turkish-locale regression test for OTP issuance.

## Validation
- `git diff --check`
- Not run locally: Maven and the Maven Wrapper are unavailable in this environment.