### PR TITLE
ci: use frozen lockfile for npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install workspace dependencies
         working-directory: frontend
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: npm run build
@@ -68,3 +68,4 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  


### PR DESCRIPTION
## What changed
- Require the npm publish workflow to install dependencies with the committed pnpm lockfile.

## Why
- Fails the release build when the lockfile is stale instead of changing it implicitly.

## Validation
- `git diff --check`