### PR TITLE
fix(docs): restore broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ Nubase is early-stage but all eight modules (Database, Auth, Storage, Assets, Fu
 
 A huge thank-you to everyone who has starred Nubase! 🙏 See the full list on the **[stargazers page »](https://github.com/OtterMind/Nubase/stargazers)**
 
+### Star history
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=OtterMind/Nubase&type=Date)](https://star-history.dera.page/#OtterMind/Nubase&type=Date)
+
 ## Contributing
 
 Contributions and issues are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and [SECURITY.md](SECURITY.md). This is an early public release, so feedback shapes what comes next. 🙌

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -231,6 +231,10 @@ Nubase 仍处于早期阶段，但全部八大模块（数据库、认证、存�
 
 衷心感谢每一位为 Nubase 点亮 Star 的朋友！🙏 完整名单见 **[stargazers 页面 »](https://github.com/OtterMind/Nubase/stargazers)**
 
+### Star 趋势
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=OtterMind/Nubase&type=Date)](https://star-history.dera.page/#OtterMind/Nubase&type=Date)
+
 ## 贡献
 
 欢迎贡献与提 issue —— 见 [CONTRIBUTING.md](CONTRIBUTING.md) 和 [SECURITY.md](SECURITY.md)。这是早期公开版本，你的反馈会塑造它接下来的方向。🙌


### PR DESCRIPTION
The Star History chart was removed in #15 because it was broken. Restore it in both README files with working chart links for the current repository so visitors can view Nubase's star history again.